### PR TITLE
Remove /sites directive for Drupal from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-# Ignore paths that contain user-generated content.
-/sites/*/files
-/sites/*/private
-
-# ** Only works in OSs that support newer versions of fnmatch (Bash 4+)
-/sites/default/**/files
-/sites/default/**/private
-
 # Wordpress #
 ############
 wp-config-local.php


### PR DESCRIPTION
A user had a /sites/ directory and also a files/ directory further down in the folder structure for some old legacy paths. The result was the directory was not committed and part of version control. 

This removes the Drupal paths from the .gitignore
