### PR TITLE
Added conditional to support WP-CLI on local clones.

### DIFF
--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -86,5 +86,5 @@ define('WP_DEBUG', false);
 if ( !defined('ABSPATH') )
 	define('ABSPATH', dirname(__FILE__) . '/');
 
-/** Sets up WordPress vars and included files. */
-require_once(ABSPATH . 'wp-settings.php');
+/** Sets up WordPress vars and included files if not in CLI mode. */
+if ( ! defined( 'WP_CLI' ) ) require_once(ABSPATH . 'wp-settings.php');


### PR DESCRIPTION
WP-CLI automatically strips the require_once out of wp-config.php, but not wp-config-local.php. Adding this conditional fixes the issue when cloning a Pantheon wordpress to local.
