### PR TITLE
Make url parsing more robust

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-cache.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-cache.php
@@ -358,7 +358,21 @@ class Pantheon_Cache {
 		foreach ( $urls as $full_url ) {
 			# Parse down to the path+query, escape regex.
 			$parsed = parse_url( $full_url );
-			$path = $parsed['path'] . $parsed['query'];
+			# Sometimes parse_url can return false, on malformed urls
+			if (FALSE == $parsed) {
+				continue;
+			}
+			# Build up the path, checking if the array key exists first
+			if (array_key_exists('path', $parsed)) {
+				$path = $parsed['path'];
+				if (array_key_exists('query', $parsed))  {
+					$path = $path . $parsed['query'];
+				}
+			}
+			# If the path doesn't exist, set it to the null string
+			else {
+				$path = '';
+			}			
 			if ( '' == $path ) {
 				continue;
 			}


### PR DESCRIPTION
There are some edge cases resulting from parse_url that weren't being taken care of.

Specifically, when there was no path part, or query part of the passed url, a warning was being output in the body of the response, breaking the JSON that was supposed to be emitted by an ajax response.

The warning was that the array key 'query' or 'path' did not exist when checking `$parsed['query']`

This fixes by defensively checking the result of parse_url to make sure the array key exists first.
