### PR TITLE
Use http host as redis key salt

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -69,6 +69,9 @@ else:
     if (isset($_SERVER['HTTP_HOST'])) {
       define('WP_HOME', 'http://' . $_SERVER['HTTP_HOST']);
       define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST']);
+      
+      // Use http host as redis key salt 
+      define('WP_CACHE_KEY_SALT', $_SERVER['HTTP_HOST']."-");
     }
     // Don't show deprecations; useful under PHP 5.5
     error_reporting(E_ALL ^ E_DEPRECATED);


### PR DESCRIPTION
As the different enviroments on Pantheon can be and WILL be accessed via different hostnames, it's important that the redis key salt uses the http host otherwise you end up with cached links, which point to different hostnames.

On the other hand .. if you bind the key salt to the hostname, you have to flush the redis cache, if you want to make sure that a (configuration) change, which is cached by redis, is available via all hostnames.

So I STRONGLY recommend if you use redis with Pantheon, that you have also a redirect in place, which makes sure that the site is only accessed by one hostname. 
http://helpdesk.getpantheon.com/customer/portal/articles/368354-redirecting-incoming-requests
