### PR TITLE
Fix bug with how Pantheon is disabling updates

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -4,7 +4,16 @@ if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], Array('test', 'live') ) ) {
   //
   // Disable Core Updates EVERYWHERE (use git upstream)
   //
-  add_filter( 'pre_site_transient_update_core', create_function( '$a', "return null;" ) );
+  function _pantheon_disable_wp_updates() {
+    include ABSPATH . WPINC . '/version.php';
+    return (object) array(
+	    'updates' => array(),
+	    'version_checked' => $wp_version,
+	    'last_checked' => time(),
+    );
+  }
+
+  add_filter( 'pre_site_transient_update_core', '_pantheon_disable_wp_updates' );
 
   //
   // Disable Plugin Updates
@@ -15,12 +24,12 @@ if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], Array('test', 'live') ) ) {
   }
 
   remove_action( 'load-update-core.php', 'wp_update_plugins' );
-  add_filter( 'pre_site_transient_update_plugins', create_function( '$a', "return null;" ) );
+  add_filter( 'pre_site_transient_update_plugins', '_pantheon_disable_wp_updates' );
 
   //
   // Disable Theme Updates
   //
   remove_action( 'load-update-core.php', 'wp_update_themes' );
-  add_filter( 'pre_site_transient_update_themes', create_function( '$a', "return null;" ) );
+  add_filter( 'pre_site_transient_update_themes', '_pantheon_disable_wp_updates' );
 }
 


### PR DESCRIPTION
As it currently stands, this is forcing WordPress to _always_ check for updates, which can cause serious lag in admin and ajax requests.
