### PR TITLE
Move WP_DEBUG to the non-local block

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ When the spin-up process is complete, you will be redirected to the site's dashb
 
 How about the WordPress database config screen? No need to worry about database connection information as that is taken care of in the background. The only step that you need to complete is the site information and the installation process will be complete.
 
-We will post more information about how this works but we recommend developers take a look at `wp-congfig.php` to get an understanding.
+We will post more information about how this works but we recommend developers take a look at `wp-config.php` to get an understanding.
 
 ![alt](http://i.imgur.com/4EOcqYN.png, '')
 

--- a/wp-config.php
+++ b/wp-config.php
@@ -95,6 +95,20 @@ else:
     define('LOGGED_IN_SALT',   'put your unique phrase here');
     define('NONCE_SALT',       'put your unique phrase here');
   endif;
+
+  /**
+   * For developers: WordPress debugging mode.
+   *
+   * Change this to true to enable the display of notices during development.
+   * It is strongly recommended that plugin and theme developers use WP_DEBUG
+   * in their development environments.
+   *
+   * You may want to examine $_ENV['PANTHEON_ENVIRONMENT'] to set this to be
+   * "true" in dev, but false in test and live.
+   */
+  define('WP_DEBUG', false);
+  
+
 endif;
 
 /** Standard wp-config.php stuff from here on down. **/
@@ -116,18 +130,6 @@ $table_prefix = 'wp_';
  * language support.
  */
 define('WPLANG', '');
-
-/**
- * For developers: WordPress debugging mode.
- *
- * Change this to true to enable the display of notices during development.
- * It is strongly recommended that plugin and theme developers use WP_DEBUG
- * in their development environments.
- *
- * You may want to examine $_ENV['PANTHEON_ENVIRONMENT'] to set this to be
- * "true" in dev, but false in test and live.
- */
-define('WP_DEBUG', false);
 
 /* That's all, stop editing! Happy Pressing. */
 


### PR DESCRIPTION
The issue is that I want to define WP_DEBUG in my wp-config-local.php file. In my local environment I turn WP_DEBUG on but in the live environment I want it off. The current setup has WP_DEBUG defined in both places which causes a warning when you set the wp-config-local.php WP_DEBUG to true. So the solution is to move the wp-config.php WP_DEBUG definition to the end of the "not using wp-config-local.php" block.
