### PR TITLE
Only force 60 second ttl in `live` environment

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-cache.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-cache.php
@@ -201,8 +201,9 @@ class Pantheon_Cache {
 	 */
 	public function cache_add_headers() {
 		$ttl = absint( $this->options['default_ttl'] );
-		if ( $ttl < 60 )
-			$ttl = 600;
+		if ( $ttl < 60 && isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && 'live' === $_ENV['PANTHEON_ENVIRONMENT'] ) {
+			$ttl = 60;
+		}
 
 		header( 'cache-control: public, max-age=' . $ttl );
 	}


### PR DESCRIPTION
Other environments, including `test` and `dev`, are fine to use 0 second
ttls.

Also makes the behavior more consistent: if the ttl value is less than
60 seconds, then it should be forced to 60 seconds, not 600.

See #17