### PR TITLE
Ignore `wp-cli.local.yml` (release-4.4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # WordPress #
 ############
 wp-config-local.php
+wp-cli.local.yml
 wp-content/uploads
 wp-content/blogs.dir/
 wp-content/upgrade/


### PR DESCRIPTION
It's intended for environment-specific project details