### PR TITLE
Let WordPress know FS writes are disabled in test and live

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -77,6 +77,11 @@ else:
         define( 'WP_TEMP_DIR', sprintf( '/srv/bindings/%s/tmp', PANTHEON_BINDING ) );
     endif;
 
+    // FS writes aren't permitted in test or live, so we should let WordPress know to disable relevant UI
+    if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) && ! defined( 'DISALLOW_FILE_MODS' ) ) :
+      define( 'DISALLOW_FILE_MODS', true );
+    endif;
+
   else:
     /**
      * This block will be executed if you have NO wp-config-local.php and you


### PR DESCRIPTION
This will automagically disable UI like the code editor and "Add
(Plugin|Theme)" experiences.