### PR TITLE
Ignore directories likely to contain large binary objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ wp-content/uploads
 wp-content/blogs.dir/
 wp-content/upgrade/
 wp-content/backup-db/
+wp-content/updraft/
+wp-content/backupwordpress-*/
+wp-content/managewp/backups/
 wp-content/advanced-cache.php
 wp-content/wp-cache-config.php
 sitemap.xml


### PR DESCRIPTION
The Updraft and BackUpWordpress plugins are likely to generate very large binary objects inside the git-backed code directory of a website. These large objects should not be stored in git and will cause problems with workflows. This change will help keep these large files out of the git history.