### PR TITLE
Remove hard-coded protocol from WP_SITEURL and WP_HOME

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -66,10 +66,12 @@ else:
     /**#@-*/
 
     /** A couple extra tweaks to help things run well on Pantheon. **/
+    
     $protocol = (  !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ||
-    			$_SERVER['SERVER_PORT'] == 443 ||
-    			(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'
-    		) ? "https://" : "http://";
+                   !empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' ||
+                   $_SERVER['SERVER_PORT'] == 443
+                ) ? "https://" : "http://";
+
     if (isset($_SERVER['HTTP_HOST'])) {
       define('WP_HOME', $protocol . $_SERVER['HTTP_HOST']);
       define('WP_SITEURL', $protocol . $_SERVER['HTTP_HOST']);

--- a/wp-config.php
+++ b/wp-config.php
@@ -66,9 +66,13 @@ else:
     /**#@-*/
 
     /** A couple extra tweaks to help things run well on Pantheon. **/
+    $protocol = (  !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' ||
+    			$_SERVER['SERVER_PORT'] == 443 ||
+    			(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'
+    		) ? "https://" : "http://";
     if (isset($_SERVER['HTTP_HOST'])) {
-      define('WP_HOME', 'http://' . $_SERVER['HTTP_HOST']);
-      define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST']);
+      define('WP_HOME', $protocol . $_SERVER['HTTP_HOST']);
+      define('WP_SITEURL', $protocol . $_SERVER['HTTP_HOST']);
     }
     // Don't show deprecations; useful under PHP 5.5
     error_reporting(E_ALL ^ E_DEPRECATED);


### PR DESCRIPTION
WP_SITEURL and WP_HOME were hard-coded to use `http` as the protocol.  Maybe they should set the protocol based on the site request, in the same way as they do with the HTTP_HOST.

This may need tweaking to work in the Pantheon environment. YMMV.

Closes pantheon-systems/Wordpress#57