### PR TITLE
Permit saving 0 ttl value in non-live; force min 60 ttl in live

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-cache.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-cache.php
@@ -154,8 +154,9 @@ class Pantheon_Cache {
 
 		// Validate default_ttl
 		$out['default_ttl'] = absint( $in['default_ttl'] );
-		if ( ! $out['default_ttl'] )
-			$out['default_ttl'] = 600;
+		if ( $out['default_ttl'] < 60 && isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && 'live' === $_ENV['PANTHEON_ENVIRONMENT'] ) {
+			$out['default_ttl'] = 60;
+		}
 
 		return $out;
 	}


### PR DESCRIPTION
Previously, this conditional would mean a ttl of 0 couldn't be saved to
the database. The conditional also didn't reflect the logic we have
elsewhere forcing a minimum of 60 for ttl in live.

Now, the conditional lets us save a ttl of 0 in non-live environments,
and enforces a minimum of 60 saved to the database in live.