### PR TITLE
Change permission check for clearing cache to reference manage_options

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-cache.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-cache.php
@@ -228,9 +228,9 @@ class Pantheon_Cache {
 		if ( ! is_user_logged_in() )
 			return false;
 
-		if ( function_exists( 'current_user_can' ) && false == current_user_can( 'delete_others_posts' ) )
-			return false;
-
+		if ( function_exists( 'current_user_can' ) && !current_user_can( 'delete_others_posts' ) )
+		  return false;
+				
 		$wp_admin_bar->add_menu( array(
 			'parent' => '',
 			'id' => 'delete-cache',
@@ -381,7 +381,7 @@ class Pantheon_Cache {
 			# If the path doesn't exist, set it to the null string
 			else {
 				$path = '';
-			}			
+			}
 			if ( '' == $path ) {
 				continue;
 			}

--- a/wp-content/mu-plugins/pantheon/pantheon-cache.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-cache.php
@@ -222,23 +222,23 @@ class Pantheon_Cache {
 	 *
 	 * @return void
 	 */
-	public function cache_admin_bar_render() {
-		global $wp_admin_bar;
+	 public function cache_admin_bar_render() {
+ 		global $wp_admin_bar;
 
-		if ( ! is_user_logged_in() )
-			return false;
+ 		if ( ! is_user_logged_in() )
+ 			return false;
 
-		if ( function_exists( 'current_user_can' ) && !current_user_can( 'delete_others_posts' ) )
-		  return false;
-				
-		$wp_admin_bar->add_menu( array(
-			'parent' => '',
-			'id' => 'delete-cache',
-			'title' => __( 'Delete Cache', 'pantheon-cache' ),
-			'meta' => array( 'title' => __( 'Delete cache of the current page', 'pantheon-cache' ) ),
-			'href' => wp_nonce_url( admin_url( 'admin-post.php?action=pantheon_cache_delete_page&path=' . urlencode( preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', $_SERVER[ 'REQUEST_URI' ] ) ) ), 'delete-cache' )
-		) );
-	}
+ 		if ( function_exists( 'current_user_can' ) && !current_user_can( 'delete_others_posts' ) )
+ 			return false;
+
+ 		$wp_admin_bar->add_menu( array(
+ 			'parent' => '',
+ 			'id' => 'delete-cache',
+ 			'title' => __( 'Delete Cache', 'pantheon-cache' ),
+ 			'meta' => array( 'title' => __( 'Delete cache of the current page', 'pantheon-cache' ) ),
+ 			'href' => wp_nonce_url( admin_url( 'admin-post.php?action=pantheon_cache_delete_page&path=' . urlencode( preg_replace( '/[ <>\'\"\r\n\t\(\)]/', '', $_SERVER[ 'REQUEST_URI' ] ) ) ), 'delete-cache' )
+ 		) );
+ 	}
 
 
 	/**

--- a/wp-content/mu-plugins/pantheon/pantheon-cache.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-cache.php
@@ -228,7 +228,7 @@ class Pantheon_Cache {
  		if ( ! is_user_logged_in() )
  			return false;
 
- 		if ( function_exists( 'current_user_can' ) && !current_user_can( 'delete_others_posts' ) )
+ 		if ( function_exists( 'current_user_can' ) && !current_user_can( 'manage_options' ) )
  			return false;
 
  		$wp_admin_bar->add_menu( array(


### PR DESCRIPTION
Currently the clear cache button uses the `delete_others_posts` permission to decide whether to be visible or not. This may be too restrictive, as some sites might have many content admins, who don't have this permission.

This PR suggests using the `manage_options` permission instead. 
