### PR TITLE
Include wp-redis object-cache.php if present.

### DIFF
--- a/wp-content/object-cache.php
+++ b/wp-content/object-cache.php
@@ -1,0 +1,7 @@
+<?php
+// Path to the wp-redis object-cache.php file.
+$wpredis_file = WP_CONTENT_DIR . '/plugins/wp-redis/object-cache.php';
+// Requires the file only if present (i.e. if the wp-redis plugin is present).
+if (file_exists($wpredis_file)) {
+  require_once $wpredis_file;
+}


### PR DESCRIPTION
This should avoid developers to add/remove the object-cache.php "symlink" when installing/removing `wp-redis`.
