### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ wp-content/backups/
 ######################
 .DS_Store*
 ehthumbs.db
-Icon?
 Thumbs.db
 ._*
 


### PR DESCRIPTION
I recommend removing `Icon?` from the gitignore as it matches files and directories in a case-insensitive way named "icons" or "icon1" etc
