### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ wp-content/backups/
 ######################
 .DS_Store*
 ehthumbs.db
-Icon?
+Icon
 Thumbs.db
 ._*
 


### PR DESCRIPTION
The `?` at the end of Icon matches any directory using this word "icon*" or "Icon*" which is bad news when you use plugins or themes with icon files or directories.