### PR TITLE
Update theme Twenty Ten to v2.2

### DIFF
--- a/wp-content/themes/twentyten/languages/twentyten.pot
+++ b/wp-content/themes/twentyten/languages/twentyten.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2015 the WordPress team
+# Copyright (C) 2016 the WordPress team
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Twenty Ten 2.1\n"
+"Project-Id-Version: Twenty Ten 2.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/twentyten\n"
-"POT-Creation-Date: 2015-12-08 15:15:12+00:00\n"
+"POT-Creation-Date: 2016-07-29 15:41:30+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2015-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
@@ -83,7 +83,7 @@ msgstr ""
 msgid "Comments are closed."
 msgstr ""
 
-#. #-#-#-#-#  twentyten.pot (Twenty Ten 2.1)  #-#-#-#-#
+#. #-#-#-#-#  twentyten.pot (Twenty Ten 2.2)  #-#-#-#-#
 #. Author URI of the plugin/theme
 #: footer.php:40
 msgid "https://wordpress.org/"

--- a/wp-content/themes/twentyten/readme.txt
+++ b/wp-content/themes/twentyten/readme.txt
@@ -1,11 +1,11 @@
 === Twenty Ten ===
 Contributors: the WordPress team
 Requires at least: WordPress 3.0
-Tested up to: WordPress 4.5-trunk
-Stable tag: 2.1
+Tested up to: WordPress 4.7-trunk
+Stable tag: 2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Tags: black, blue, white, two-columns, fixed-layout, custom-header, custom-background, threaded-comments, sticky-post, translation-ready, microformats, rtl-language-support, editor-style, custom-menu, flexible-header, featured-images, featured-image-header
+Tags: blog, two-columns, custom-header, custom-background, threaded-comments, sticky-post, translation-ready, microformats, rtl-language-support, editor-style, custom-menu, flexible-header, featured-images, footer-widgets, featured-image-header
 
 == Description ==
 The 2010 theme for WordPress is stylish, customizable, simple, and readable -- make it yours with a custom menu, header image, and background. Twenty Ten supports six widgetized areas (two in the sidebar, four in the footer) and featured images (thumbnails for gallery posts and custom header images for posts and pages). It includes stylesheets for print and the admin Visual Editor, special styles for posts in the "Asides" and "Gallery" categories, and has an optional one-column page template that removes the sidebar.
@@ -22,7 +22,7 @@ For more information about Twenty Ten theme please go to https://codex.wordpress
 
 == Copyright ==
 
-Twenty Ten WordPress Theme, Copyright 2010-2015 WordPress.org & Automattic.com
+Twenty Ten WordPress Theme, Copyright 2010-2016 WordPress.org & Automattic.com
 Twenty Ten is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify
@@ -36,6 +36,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 == Changelog ==
+
+= 2.2 =
+* Released: August 15, 2016
+
+https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.2
 
 = 2.1 =
 * Released: December 8, 2015

--- a/wp-content/themes/twentyten/style.css
+++ b/wp-content/themes/twentyten/style.css
@@ -4,10 +4,10 @@ Theme URI: https://wordpress.org/themes/twentyten/
 Description: The 2010 theme for WordPress is stylish, customizable, simple, and readable -- make it yours with a custom menu, header image, and background. Twenty Ten supports six widgetized areas (two in the sidebar, four in the footer) and featured images (thumbnails for gallery posts and custom header images for posts and pages). It includes stylesheets for print and the admin Visual Editor, special styles for posts in the "Asides" and "Gallery" categories, and has an optional one-column page template that removes the sidebar.
 Author: the WordPress team
 Author URI: https://wordpress.org/
-Version: 2.1
+Version: 2.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Tags: black, blue, white, two-columns, fixed-layout, custom-header, custom-background, threaded-comments, sticky-post, translation-ready, microformats, rtl-language-support, editor-style, custom-menu, flexible-header, featured-images, featured-image-header
+Tags: blog, two-columns, custom-header, custom-background, threaded-comments, sticky-post, translation-ready, microformats, rtl-language-support, editor-style, custom-menu, flexible-header, featured-images, footer-widgets, featured-image-header
 Text Domain: twentyten
 */
 


### PR DESCRIPTION
This pull request updates Twenty Ten to the latest release, version 2.2 (15 August 2016).

https://wordpress.org/themes/twentyten/

---

For more background on why this pull request is needed, see #103.