### PR TITLE
Update theme Twenty Eleven to v2.5

### DIFF
--- a/wp-content/themes/twentyeleven/editor-style.css
+++ b/wp-content/themes/twentyeleven/editor-style.css
@@ -3,21 +3,12 @@ Theme Name: Twenty Eleven
 Description: Used to style the TinyMCE editor.
 */
 
-html .mceContentBody {
-	max-width: 584px;
-}
-* {
-	color: inherit;
-	font: 15px "Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-style: inherit;
-	font-weight: inherit;
-	line-height: 1.625;
-}
 body {
 	color: #333;
 	font: 15px "Helvetica Neue", Helvetica, Arial, "Nimbus Sans L", sans-serif;
 	font-weight: 300;
 	line-height: 1.625;
+	max-width: 584px;
 }
 
 /* Headings */
@@ -237,10 +228,6 @@ td {
 }
 
 /* Images */
-img[class*="wp-image-"] {
-	height: auto;
-	max-width: 97.5%;
-}
 img.size-full {
 	width: auto; /* Prevent stretching of full-size images in IE8 */
 }
@@ -254,10 +241,12 @@ p img,
 .wp-caption {
 	margin-top: 0.4em;
 }
-img,
-.editor-attachment {
+img {
 	border: 1px solid #ddd;
 	padding: 6px;
+	height: auto;
+	max-width: 97.5%;
+	max-width: calc( 100% - 14px );
 }
 img.alignleft,
 img.alignright,
@@ -269,25 +258,25 @@ img.aligncenter {
 	border: none;
 	margin-bottom: 1.625em;
 	max-width: 96%;
-	padding: 9px;
+	max-width: calc( 100% - 22px );
+	padding: 9px 11px;
 }
 .wp-caption img {
 	display: block;
-	margin: 5px auto 0 !important;
+	margin: 0 -2px;
 	max-width: 98%;
+	max-width: calc( 100% - 10px );
 	border-color: #eee;
 }
-.wp-caption .wp-caption-text,
-.wp-caption-dd {
+.wp-caption .wp-caption-dd {
 	color: #666;
-	font-family: Georgia, serif !important;
+	font-family: Georgia, serif;
 	font-size: 12px;
-	margin: 0 0 0.6em 0 !important;
-	padding: 0 0 5px 40px;
+	margin-bottom: 0.6em;
+	padding: 10px 0 5px 40px;
 	position: relative;
-	text-align: left;
 }
-.wp-caption .wp-caption-text:before {
+.wp-caption .wp-caption-dd:before {
 	color: #666;
 	content: '\2014';
 	font-size: 14px;
@@ -298,9 +287,9 @@ img.aligncenter {
 	left: 10px;
 	top: 7px;
 }
-a:focus img[class*="wp-image-"],
-a:hover img[class*="wp-image-"],
-a:active img[class*="wp-image-"] {
+a:focus img,
+a:hover img,
+a:active img {
 	background: #eee;
 	border-color: #bbb;
 }

--- a/wp-content/themes/twentyeleven/functions.php
+++ b/wp-content/themes/twentyeleven/functions.php
@@ -226,6 +226,9 @@ function twentyeleven_setup() {
 			'description' => __( 'Hanoi Plant', 'twentyeleven' )
 		)
 	) );
+
+	// Indicate widget sidebars can use selective refresh in the Customizer.
+	add_theme_support( 'customize-selective-refresh-widgets' );
 }
 endif; // twentyeleven_setup
 

--- a/wp-content/themes/twentyeleven/inc/theme-options.php
+++ b/wp-content/themes/twentyeleven/inc/theme-options.php
@@ -510,6 +510,19 @@ function twentyeleven_customize_register( $wp_customize ) {
 	$wp_customize->get_setting( 'blogdescription' )->transport = 'postMessage';
 	$wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage';
 
+	if ( isset( $wp_customize->selective_refresh ) ) {
+		$wp_customize->selective_refresh->add_partial( 'blogname', array(
+			'selector' => '#site-title a',
+			'container_inclusive' => false,
+			'render_callback' => 'twentyeleven_customize_partial_blogname',
+		) );
+		$wp_customize->selective_refresh->add_partial( 'blogdescription', array(
+			'selector' => '#site-description',
+			'container_inclusive' => false,
+			'render_callback' => 'twentyeleven_customize_partial_blogdescription',
+		) );
+	}
+
 	$options  = twentyeleven_get_theme_options();
 	$defaults = twentyeleven_get_default_theme_options();
 
@@ -573,6 +586,30 @@ function twentyeleven_customize_register( $wp_customize ) {
 	) );
 }
 add_action( 'customize_register', 'twentyeleven_customize_register' );
+
+/**
+ * Render the site title for the selective refresh partial.
+ *
+ * @since Twenty Eleven 2.4
+ * @see twentyeleven_customize_register()
+ *
+ * @return void
+ */
+function twentyeleven_customize_partial_blogname() {
+	bloginfo( 'name' );
+}
+
+/**
+ * Render the site tagline for the selective refresh partial.
+ *
+ * @since Twenty Eleven 2.4
+ * @see twentyeleven_customize_register()
+ *
+ * @return void
+ */
+function twentyeleven_customize_partial_blogdescription() {
+	bloginfo( 'description' );
+}
 
 /**
  * Bind JS handlers to make Customizer preview reload changes asynchronously.

--- a/wp-content/themes/twentyeleven/inc/widgets.php
+++ b/wp-content/themes/twentyeleven/inc/widgets.php
@@ -21,6 +21,7 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 		parent::__construct( 'widget_twentyeleven_ephemera', __( 'Twenty Eleven Ephemera', 'twentyeleven' ), array(
 			'classname'   => 'widget_twentyeleven_ephemera',
 			'description' => __( 'Use this widget to list your recent Aside, Status, Quote, and Link posts', 'twentyeleven' ),
+			'customize_selective_refresh' => true,
 		) );
 		$this->alt_option_name = 'widget_twentyeleven_ephemera';
 
@@ -55,7 +56,7 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 		if ( ! isset( $args['widget_id'] ) )
 			$args['widget_id'] = null;
 
-		if ( isset( $cache[ $args['widget_id'] ] ) ) {
+		if ( ! is_customize_preview() && isset( $cache[ $args['widget_id'] ] ) ) {
 			echo $cache[ $args['widget_id'] ];
 			return;
 		}
@@ -131,7 +132,10 @@ class Twenty_Eleven_Ephemera_Widget extends WP_Widget {
 		endif;
 
 		$cache[ $args['widget_id'] ] = ob_get_flush();
-		wp_cache_set( 'widget_twentyeleven_ephemera', $cache, 'widget' );
+		if ( ! is_customize_preview() ) {
+			wp_cache_set( 'widget_twentyeleven_ephemera', $cache, 'widget' );
+		}
+
 	}
 
 	/**

--- a/wp-content/themes/twentyeleven/languages/twentyeleven.pot
+++ b/wp-content/themes/twentyeleven/languages/twentyeleven.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2015 the WordPress team
+# Copyright (C) 2016 the WordPress team
 # This file is distributed under the GNU General Public License v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Twenty Eleven 2.3\n"
+"Project-Id-Version: Twenty Eleven 2.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/twentyeleven\n"
-"POT-Creation-Date: 2015-12-08 15:13:33+00:00\n"
+"POT-Creation-Date: 2016-07-29 15:41:03+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2015-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
@@ -130,7 +130,7 @@ msgstr ""
 
 #: content-aside.php:35 content-gallery.php:34 content-image.php:29
 #: content-link.php:35 content-quote.php:35 content-status.php:48
-#: content.php:41 functions.php:375
+#: content.php:41 functions.php:378
 msgid "Continue reading <span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
@@ -162,7 +162,7 @@ msgstr ""
 #: content-aside.php:46 content-featured.php:45 content-gallery.php:88
 #: content-image.php:70 content-intro.php:19 content-link.php:46
 #: content-page.php:21 content-quote.php:72 content-single.php:52
-#: content-status.php:59 content.php:82 functions.php:609 functions.php:637
+#: content-status.php:59 content.php:82 functions.php:612 functions.php:640
 #: image.php:41
 msgid "Edit"
 msgstr ""
@@ -223,7 +223,7 @@ msgid ""
 "\" rel=\"author\">%6$s</a></span></span>"
 msgstr ""
 
-#: content-image.php:41 functions.php:675
+#: content-image.php:41 functions.php:678
 msgid "View all posts by %s"
 msgstr ""
 
@@ -266,7 +266,7 @@ msgstr ""
 msgid "Featured"
 msgstr ""
 
-#. #-#-#-#-#  twentyeleven.pot (Twenty Eleven 2.3)  #-#-#-#-#
+#. #-#-#-#-#  twentyeleven.pot (Twenty Eleven 2.5)  #-#-#-#-#
 #. Author URI of the plugin/theme
 #: footer.php:28
 msgid "https://wordpress.org/"
@@ -324,69 +324,69 @@ msgstr ""
 msgid "Hanoi Plant"
 msgstr ""
 
-#: functions.php:446
+#: functions.php:449
 msgid "Main Sidebar"
 msgstr ""
 
-#: functions.php:455
+#: functions.php:458
 msgid "Showcase Sidebar"
 msgstr ""
 
-#: functions.php:457
+#: functions.php:460
 msgid "The sidebar for the optional Showcase Template"
 msgstr ""
 
-#: functions.php:465
+#: functions.php:468
 msgid "Footer Area One"
 msgstr ""
 
-#: functions.php:467 functions.php:477 functions.php:487
+#: functions.php:470 functions.php:480 functions.php:490
 msgid "An optional widget area for your site footer"
 msgstr ""
 
-#: functions.php:475
+#: functions.php:478
 msgid "Footer Area Two"
 msgstr ""
 
-#: functions.php:485
+#: functions.php:488
 msgid "Footer Area Three"
 msgstr ""
 
-#: functions.php:509 single.php:18
+#: functions.php:512 single.php:18
 msgid "Post navigation"
 msgstr ""
 
-#: functions.php:510
+#: functions.php:513
 msgid "<span class=\"meta-nav\">&larr;</span> Older posts"
 msgstr ""
 
-#: functions.php:511
+#: functions.php:514
 msgid "Newer posts <span class=\"meta-nav\">&rarr;</span>"
 msgstr ""
 
-#: functions.php:609
+#: functions.php:612
 msgid "Pingback:"
 msgstr ""
 
 #. translators: 1: comment author, 2: date and time
-#: functions.php:626
+#: functions.php:629
 msgid "%1$s on %2$s <span class=\"says\">said:</span>"
 msgstr ""
 
 #. translators: 1: date, 2: time
-#: functions.php:632
+#: functions.php:635
 msgid "%1$s at %2$s"
 msgstr ""
 
-#: functions.php:641
+#: functions.php:644
 msgid "Your comment is awaiting moderation."
 msgstr ""
 
-#: functions.php:650
+#: functions.php:653
 msgid "Reply <span>&darr;</span>"
 msgstr ""
 
-#: functions.php:669
+#: functions.php:672
 msgid ""
 "<span class=\"sep\">Posted on </span><a href=\"%1$s\" title=\"%2$s\" rel="
 "\"bookmark\"><time class=\"entry-date\" datetime=\"%3$s\">%4$s</time></"
@@ -431,11 +431,11 @@ msgid ""
 "in <a href=\"%6$s\" title=\"Return to %7$s\" rel=\"gallery\">%8$s</a>"
 msgstr ""
 
-#: inc/theme-options.php:56 inc/theme-options.php:529
+#: inc/theme-options.php:56 inc/theme-options.php:542
 msgid "Color Scheme"
 msgstr ""
 
-#: inc/theme-options.php:62 inc/theme-options.php:546
+#: inc/theme-options.php:62 inc/theme-options.php:559
 msgid "Link Color"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "%s Theme Options"
 msgstr ""
 
-#: inc/theme-options.php:553
+#: inc/theme-options.php:566
 msgid "Layout"
 msgstr ""
 
@@ -547,27 +547,27 @@ msgid ""
 "Use this widget to list your recent Aside, Status, Quote, and Link posts"
 msgstr ""
 
-#: inc/widgets.php:67
+#: inc/widgets.php:68
 msgid "Ephemera"
 msgstr ""
 
-#: inc/widgets.php:106 inc/widgets.php:115
+#: inc/widgets.php:107 inc/widgets.php:116
 msgid "0 <span class=\"reply\">comments &rarr;</span>"
 msgstr ""
 
-#: inc/widgets.php:106 inc/widgets.php:115
+#: inc/widgets.php:107 inc/widgets.php:116
 msgid "1 <span class=\"reply\">comment &rarr;</span>"
 msgstr ""
 
-#: inc/widgets.php:106 inc/widgets.php:115
+#: inc/widgets.php:107 inc/widgets.php:116
 msgid "% <span class=\"reply\">comments &rarr;</span>"
 msgstr ""
 
-#: inc/widgets.php:178
+#: inc/widgets.php:182
 msgid "Title:"
 msgstr ""
 
-#: inc/widgets.php:181
+#: inc/widgets.php:185
 msgid "Number of posts to show:"
 msgstr ""
 

--- a/wp-content/themes/twentyeleven/readme.txt
+++ b/wp-content/themes/twentyeleven/readme.txt
@@ -1,11 +1,11 @@
 === Twenty Eleven ===
 Contributors: the WordPress team
 Requires at least: WordPress 3.2
-Tested up to: WordPress 4.5-trunk
-Stable tag: 2.3
+Tested up to: WordPress 4.7-trunk
+Stable tag: 2.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Tags: dark, light, white, black, gray, one-column, two-columns, left-sidebar, right-sidebar, fixed-layout, responsive-layout, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-image-header, featured-images, flexible-header, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready
+Tags: blog, one-column, two-columns, left-sidebar, right-sidebar, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-image-header, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready
 
 == Description ==
 The 2011 theme for WordPress is sophisticated, lightweight, and adaptable. Make it yours with a custom menu, header image, and background -- then go further with available theme options for light or dark color scheme, custom link colors, and three layout choices. Twenty Eleven comes equipped with a Showcase page template that transforms your front page into a showcase to show off your best content, widget support galore (sidebar, three footer areas, and a Showcase page widget area), and a custom "Ephemera" widget to display your Aside, Link, Quote, or Status posts. Included are styles for print and for the admin editor, support for featured images (as custom header images on posts and pages and as large images on featured "sticky" posts), and special styles for six different post formats.
@@ -22,7 +22,7 @@ For more information about Twenty Eleven please go to https://codex.wordpress.or
 
 == Copyright ==
 
-Twenty Eleven WordPress Theme, Copyright 2011-2015 WordPress.org & Automattic.com
+Twenty Eleven WordPress Theme, Copyright 2011-2016 WordPress.org & Automattic.com
 Twenty Eleven is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify
@@ -42,6 +42,16 @@ Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
 == Changelog ==
+
+= 2.5 =
+* Released: August 15, 2016
+
+https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.5
+
+= 2.4 =
+* Released: April 12, 2016
+
+https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.4
 
 = 2.3 =
 * Released: December 8, 2015

--- a/wp-content/themes/twentyeleven/style.css
+++ b/wp-content/themes/twentyeleven/style.css
@@ -4,10 +4,10 @@ Theme URI: https://wordpress.org/themes/twentyeleven/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2011 theme for WordPress is sophisticated, lightweight, and adaptable. Make it yours with a custom menu, header image, and background -- then go further with available theme options for light or dark color scheme, custom link colors, and three layout choices. Twenty Eleven comes equipped with a Showcase page template that transforms your front page into a showcase to show off your best content, widget support galore (sidebar, three footer areas, and a Showcase page widget area), and a custom "Ephemera" widget to display your Aside, Link, Quote, or Status posts. Included are styles for print and for the admin editor, support for featured images (as custom header images on posts and pages and as large images on featured "sticky" posts), and special styles for six different post formats.
-Version: 2.3
+Version: 2.5
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Tags: dark, light, white, black, gray, one-column, two-columns, left-sidebar, right-sidebar, fixed-layout, responsive-layout, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-image-header, featured-images, flexible-header, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready
+Tags: blog, one-column, two-columns, left-sidebar, right-sidebar, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-image-header, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready
 Text Domain: twentyeleven
 */
 
@@ -910,12 +910,13 @@ p img,
 	background: #eee;
 	margin-bottom: 1.625em;
 	max-width: 96%;
+	max-width: calc( 100% - 18px );
 	padding: 9px;
 }
 .wp-caption img {
 	display: block;
-	margin: -2px 0 0 -2px;
 	max-width: 98%;
+	max-width: calc( 100% - 14px );
 }
 .wp-caption .wp-caption-text,
 .gallery-caption {
@@ -965,6 +966,7 @@ img[class*="wp-image-"],
 	border: 1px solid #ddd;
 	padding: 6px;
 	max-width: 97.5%;
+	max-width: calc( 100% - 14px );
 }
 .wp-caption img {
 	border-color: #eee;


### PR DESCRIPTION
This pull request updates Twenty Eleven to the latest release, version 2.5 (15 August 2016).

https://wordpress.org/themes/twentyeleven/

---

For more background on why this pull request is needed, see #103.