### PR TITLE
Update theme Twenty Seventeen to v1.1

### DIFF
--- a/wp-content/themes/twentyseventeen/README.txt
+++ b/wp-content/themes/twentyseventeen/README.txt
@@ -1,8 +1,8 @@
 === Twenty Seventeen ===
 Contributors: the WordPress team
-Requires at least: WordPress 4.8-trunk
+Requires at least: WordPress 4.7
 Tested up to: WordPress 4.7
-Version: 1.0
+Version: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready
@@ -59,6 +59,14 @@ License: CC0 1.0 Universal (CC0 1.0)
 Source: https://unsplash.com/@englr?photo=bIhpiQA009k
 
 == Changelog ==
+
+= 1.1 =
+* Released: January 6, 2017
+
+- Fix incorrect $content_width value in theme
+- Ensure functions in customize-controls.js don't count on Customizer sections always being present
+- Deprecate page_home nav menu item starter content
+- Introduce a theme-specific filter twentyseventeen_starter_content for customizing the starter content array
 
 = 1.0 =
 * Released: December 6, 2016

--- a/wp-content/themes/twentyseventeen/assets/js/customize-controls.js
+++ b/wp-content/themes/twentyseventeen/assets/js/customize-controls.js
@@ -25,10 +25,12 @@
 		});
 
 		// Detect when the front page sections section is expanded (or closed) so we can adjust the preview accordingly.
-		wp.customize.section( 'theme_options' ).expanded.bind( function( isExpanding ) {
+		wp.customize.section( 'theme_options', function( section ) {
+			section.expanded.bind( function( isExpanding ) {
 
-			// Value of isExpanding will = true if you're entering the section, false if you're leaving it.
-			wp.customize.previewer.send( 'section-highlight', { expanded: isExpanding });
-		});
+				// Value of isExpanding will = true if you're entering the section, false if you're leaving it.
+				wp.customize.previewer.send( 'section-highlight', { expanded: isExpanding });
+			} );
+		} );
 	});
 })( jQuery );

--- a/wp-content/themes/twentyseventeen/functions.php
+++ b/wp-content/themes/twentyseventeen/functions.php
@@ -55,6 +55,9 @@ function twentyseventeen_setup() {
 
 	add_image_size( 'twentyseventeen-thumbnail-avatar', 100, 100, true );
 
+	// Set the default content width.
+	$GLOBALS['content_width'] = 525;
+
 	// This theme uses wp_nav_menu() in two locations.
 	register_nav_menus( array(
 		'top'    => __( 'Top Menu', 'twentyseventeen' ),
@@ -103,24 +106,29 @@ function twentyseventeen_setup() {
  	 */
 	add_editor_style( array( 'assets/css/editor-style.css', twentyseventeen_fonts_url() ) );
 
-	add_theme_support( 'starter-content', array(
+	// Define and register starter content to showcase the theme on new sites.
+	$starter_content = array(
 		'widgets' => array(
+			// Place three core-defined widgets in the sidebar area.
 			'sidebar-1' => array(
 				'text_business_info',
 				'search',
 				'text_about',
 			),
 
+			// Add the core-defined business info widget to the footer 1 area.
 			'sidebar-2' => array(
 				'text_business_info',
 			),
 
+			// Put two core-defined widgets in the footer 2 area.
 			'sidebar-3' => array(
 				'text_about',
 				'search',
 			),
 		),
 
+		// Specify the core-defined pages to create and add custom thumbnails to some of them.
 		'posts' => array(
 			'home',
 			'about' => array(
@@ -137,10 +145,11 @@ function twentyseventeen_setup() {
 			),
 		),
 
+		// Create the custom image attachments used as post thumbnails for pages.
 		'attachments' => array(
 			'image-espresso' => array(
 				'post_title' => _x( 'Espresso', 'Theme starter content', 'twentyseventeen' ),
-				'file' => 'assets/images/espresso.jpg',
+				'file' => 'assets/images/espresso.jpg', // URL relative to the template directory.
 			),
 			'image-sandwich' => array(
 				'post_title' => _x( 'Sandwich', 'Theme starter content', 'twentyseventeen' ),
@@ -152,12 +161,14 @@ function twentyseventeen_setup() {
 			),
 		),
 
+		// Default to a static front page and assign the front and posts pages.
 		'options' => array(
 			'show_on_front' => 'page',
 			'page_on_front' => '{{home}}',
 			'page_for_posts' => '{{blog}}',
 		),
 
+		// Set the front page section theme mods to the IDs of the core-registered pages.
 		'theme_mods' => array(
 			'panel_1' => '{{homepage-section}}',
 			'panel_2' => '{{about}}',
@@ -165,16 +176,20 @@ function twentyseventeen_setup() {
 			'panel_4' => '{{contact}}',
 		),
 
+		// Set up nav menus for each of the two areas registered in the theme.
 		'nav_menus' => array(
+			// Assign a menu to the "top" location.
 			'top' => array(
 				'name' => __( 'Top Menu', 'twentyseventeen' ),
 				'items' => array(
-					'page_home',
+					'link_home', // Note that the core "home" page is actually a link in case a static front page is not used.
 					'page_about',
 					'page_blog',
 					'page_contact',
 				),
 			),
+
+			// Assign a menu to the "social" location.
 			'social' => array(
 				'name' => __( 'Social Links Menu', 'twentyseventeen' ),
 				'items' => array(
@@ -186,7 +201,18 @@ function twentyseventeen_setup() {
 				),
 			),
 		),
-	) );
+	);
+
+	/**
+	 * Filters Twenty Seventeen array of starter content.
+	 *
+	 * @since Twenty Seventeen 1.1
+	 *
+	 * @param array $starter_content Array of starter content.
+	 */
+	$starter_content = apply_filters( 'twentyseventeen_starter_content', $starter_content );
+
+	add_theme_support( 'starter-content', $starter_content );
 }
 add_action( 'after_setup_theme', 'twentyseventeen_setup' );
 
@@ -199,10 +225,23 @@ add_action( 'after_setup_theme', 'twentyseventeen_setup' );
  */
 function twentyseventeen_content_width() {
 
-	$content_width = 700;
+	$content_width = $GLOBALS['content_width'];
 
-	if ( twentyseventeen_is_frontpage() ) {
-		$content_width = 1120;
+	// Get layout.
+	$page_layout = get_theme_mod( 'page_layout' );
+
+	// Check if layout is one column.
+	if ( 'one-column' === $page_layout ) {
+		if ( twentyseventeen_is_frontpage() ) {
+			$content_width = 644;
+		} elseif ( is_page() ) {
+			$content_width = 740;
+		}
+	}
+
+	// Check if is single post and there is no sidebar.
+	if ( is_single() && ! is_active_sidebar( 'sidebar-1' ) ) {
+		$content_width = 740;
 	}
 
 	/**
@@ -214,7 +253,7 @@ function twentyseventeen_content_width() {
 	 */
 	$GLOBALS['content_width'] = apply_filters( 'twentyseventeen_content_width', $content_width );
 }
-add_action( 'after_setup_theme', 'twentyseventeen_content_width', 0 );
+add_action( 'template_redirect', 'twentyseventeen_content_width', 0 );
 
 /**
  * Register custom fonts.

--- a/wp-content/themes/twentyseventeen/style.css
+++ b/wp-content/themes/twentyseventeen/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.org/themes/twentyseventeen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
-Version: 1.0
+Version: 1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentyseventeen

--- a/wp-content/themes/twentyseventeen/template-parts/header/header-image.php
+++ b/wp-content/themes/twentyseventeen/template-parts/header/header-image.php
@@ -11,9 +11,9 @@
 ?>
 <div class="custom-header">
 
-		<div class="custom-header-media">
-			<?php the_custom_header_markup(); ?>
-		</div>
+	<div class="custom-header-media">
+		<?php the_custom_header_markup(); ?>
+	</div>
 
 	<?php get_template_part( 'template-parts/header/site', 'branding' ); ?>
 


### PR DESCRIPTION
This pull request updates Twenty Seventeen to the latest release, version 1.1 (11 January 2017).

https://wordpress.org/themes/twentyseventeen/

---

For more background on why this pull request is needed, see #103.