### PR TITLE
Replace WordPress update nag with our own

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -34,7 +34,7 @@ function _pantheon_wordpress_update_available() {
 	include( ABSPATH . WPINC . '/version.php' );
 	
 	// Return true if our version is not the latest
-	return $latest_wp_version > $wp_version;
+	return version_compare( $latest_wp_version, $wp_version, '>' );
 
 }
 

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -1,5 +1,5 @@
 <?php
-// Disable WordPress ato updates
+// Disable WordPress auto updates
 if( ! defined('WP_AUTO_UPDATE_CORE')) {
 	define( 'WP_AUTO_UPDATE_CORE', false );
 }
@@ -61,6 +61,15 @@ function _pantheon_register_upstream_update_notice(){
 	if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && _pantheon_wordpress_update_available() ){
 		add_action( 'admin_notices', '_pantheon_upstream_update_notice' );
 	}
+}
+
+function _pantheon_disable_wp_updates() {
+	include ABSPATH . WPINC . '/version.php';
+	return (object) array(
+		'updates' => array(),
+		'version_checked' => $wp_version,
+		'last_checked' => time(),
+	);
 }
 
 // Only in Test and Live Environments...

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -46,9 +46,9 @@ function _pantheon_upstream_update_notice() {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
     ?>
     <div class="update-nag">
-		<h3>
-			"WordPress <?php echo $latest_wp_version; ?> is available! Please update to WordPress <?php echo $latest_wp_version; ?> from <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>">your Pantheon dashboard</a>.
-		</h3>
+		<p style="font-size: 14px; font-weight: bold; margin: 0 0 0.5em 0;">
+			WordPress <?php echo $latest_wp_version; ?> is available! Please update from <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>">your Pantheon dashboard</a>.
+		</p>
 		For details on applying updates, see <a href="https://pantheon.io/docs/upstream-updates/" target="_blank">the Applying Upstream Updates documentation</a>. <br />
 		If you need help, open a support chat on Pantheon.
 	</div>

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -49,7 +49,7 @@ function _pantheon_upstream_update_notice() {
 		<p style="font-size: 14px; font-weight: bold; margin: 0 0 0.5em 0;">
 			WordPress <?php echo $latest_wp_version; ?> is available! Please update from <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>">your Pantheon dashboard</a>.
 		</p>
-		For details on applying updates, see <a href="https://pantheon.io/docs/upstream-updates/" target="_blank">the Applying Upstream Updates documentation</a>. <br />
+		For details on applying updates, see the <a href="https://pantheon.io/docs/upstream-updates/" target="_blank">Applying Upstream Updates</a> documentation. <br />
 		If you need help, open a support chat on Pantheon.
 	</div>
     <?php

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -1,35 +1,76 @@
 <?php
+// Disable WordPress ato updates
+if( ! defined('WP_AUTO_UPDATE_CORE')) {
+	define( 'WP_AUTO_UPDATE_CORE', false );
+}
+remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
+
+// Remove WordPress core update nag
+add_action('admin_menu','_pantheon_hide_update_nag');
+function _pantheon_hide_update_nag() {
+	remove_action( 'admin_notices', 'update_nag', 3 );
+}
+
+// Get the latest WordPress version
+function _pantheon_get_latest_wordpress_version() {
+	$core_updates = get_core_updates( array('dismissed' => false) );
+
+	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) ){
+		return null;
+	}
+
+	return $core_updates[0]->current;
+}
+
+// Compare the current WordPress version to the latest available
+function _pantheon_wordpress_update_available() {
+	$latest_wp_version = _pantheon_get_latest_wordpress_version();
+
+	if( null === latest_wp_version ){
+		return false;
+	}
+
+	// include an unmodified $wp_version
+	include( ABSPATH . WPINC . '/version.php' );
+	
+	// Return true if our version is not the latest
+	return $latest_wp_version > $wp_version;
+
+}
+
+// Replace WordPress core update nag EVERYWHERE with our own notice (use git upstream)
+function _pantheon_upstream_update_notice() {
+	// include an unmodified $wp_version
+	include( ABSPATH . WPINC . '/version.php' );
+
+	$latest_wp_version = _pantheon_get_latest_wordpress_version();
+    ?>
+    <div class="update-nag">
+	<h3>Please check <a href="http://dev-<?php echo $_ENV['PANTHEON_SITE_NAME']; ?>.pantheonsite.io/"> the Pantheon dashboard</a> to see if a WordPress update is available on the platform.</h3>
+		Your WordPress version of <?php echo $wp_version; ?> is out of date (the current version is <?php echo $latest_wp_version; ?>)<br />
+		If you need help, please see <a href="https://pantheon.io/docs/upstream-updates/">the documentation</a> for details or open a support chat.
+	</div>
+    <?php
+}
+
+// Register our admin notice
+add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
+function _pantheon_register_upstream_update_notice(){
+	if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && _pantheon_wordpress_update_available() ){
+		add_action( 'admin_notices', '_pantheon_upstream_update_notice' );
+	}
+}
+
 // Only in Test and Live Environments...
 if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], Array('test', 'live') ) ) {
-	//
-	// Disable Core Updates EVERYWHERE (use git upstream)
-	//
-	function _pantheon_disable_wp_updates() {
-		include ABSPATH . WPINC . '/version.php';
-		return (object) array(
-			'updates' => array(),
-			'version_checked' => $wp_version,
-			'last_checked' => time(),
-		);
-	}
 
-	add_filter( 'pre_site_transient_update_core', '_pantheon_disable_wp_updates' );
-
-	//
 	// Disable Plugin Updates
-	//
-	add_action('admin_menu','_pantheon_hide_admin_notices');
-	function _pantheon_hide_admin_notices() {
-		remove_action( 'admin_notices', 'update_nag', 3 );
-	}
-
 	remove_action( 'load-update-core.php', 'wp_update_plugins' );
 	add_filter( 'pre_site_transient_update_plugins', '_pantheon_disable_wp_updates' );
 
-	//
 	// Disable Theme Updates
-	//
 	remove_action( 'load-update-core.php', 'wp_update_themes' );
 	add_filter( 'pre_site_transient_update_themes', '_pantheon_disable_wp_updates' );
 }
+
 

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -46,7 +46,7 @@ function _pantheon_upstream_update_notice() {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
     ?>
     <div class="update-nag">
-	<h3>Please check <a href="http://dev-<?php echo $_ENV['PANTHEON_SITE_NAME']; ?>.pantheonsite.io/"> the Pantheon dashboard</a> to see if a WordPress update is available on the platform.</h3>
+	<h3>Please check <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>"> to see if a WordPress update is available on the platform.</h3>
 		Your WordPress version of <?php echo $wp_version; ?> is out of date (the current version is <?php echo $latest_wp_version; ?>)<br />
 		If you need help, please see <a href="https://pantheon.io/docs/upstream-updates/">the documentation</a> for details or open a support chat.
 	</div>

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -46,9 +46,11 @@ function _pantheon_upstream_update_notice() {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
     ?>
     <div class="update-nag">
-	<h3>Please check <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>"> to see if a WordPress update is available on the platform.</h3>
-		Your WordPress version of <?php echo $wp_version; ?> is out of date (the current version is <?php echo $latest_wp_version; ?>)<br />
-		If you need help, please see <a href="https://pantheon.io/docs/upstream-updates/">the documentation</a> for details or open a support chat.
+		<h3>
+			"WordPress <?php echo $latest_wp_version; ?> is available! Please update to WordPress <?php echo $latest_wp_version; ?> from <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>">your Pantheon dashboard</a>.
+		</h3>
+		For details on applying updates, see <a href="https://pantheon.io/docs/upstream-updates/" target="_blank">the Applying Upstream Updates documentation</a>. <br />
+		If you need help, open a support chat on Pantheon.
 	</div>
     <?php
 }

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -26,7 +26,7 @@ function _pantheon_get_latest_wordpress_version() {
 function _pantheon_wordpress_update_available() {
 	$latest_wp_version = _pantheon_get_latest_wordpress_version();
 
-	if( null === latest_wp_version ){
+	if( null === $latest_wp_version ){
 		return false;
 	}
 


### PR DESCRIPTION
Edit: **The process for updating WordPress on Pantheon is different. We need to tell people that (or remind them).**

I refactored our mu-plugin. Previously it stopped WordPress from running version checks.

I allowed WordPress to run version checks then use the result to determine if we should display our own nag message, removing the default.

The previous logic also only stopped WordPress updates on test and live. The new nag message applies to all environments.

It looks like this:
![pantheon-update-nag](https://user-images.githubusercontent.com/2133004/27886033-f0efb25a-619f-11e7-800f-6c15f2142678.png)