### PR TITLE
Check for existence of WPLANG before defining it

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -51,7 +51,7 @@ else:
      * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
      *
      * Pantheon sets these values for you also. If you want to shuffle them you
-     * must contact support: https://pantheon.io/docs/getting-support 
+     * must contact support: https://pantheon.io/docs/getting-support
      *
      * @since 2.6.0
      */
@@ -67,7 +67,7 @@ else:
 
     /** A couple extra tweaks to help things run well on Pantheon. **/
     if (isset($_SERVER['HTTP_HOST'])) {
-        // HTTP is still the default scheme for now. 
+        // HTTP is still the default scheme for now.
         $scheme = 'http';
         // If we have detected that the end use is HTTPS, make sure we pass that
         // through here, so <img> tags and the like don't generate mixed-mode
@@ -132,8 +132,9 @@ $table_prefix = 'wp_';
  * de_DE.mo to wp-content/languages and set WPLANG to 'de_DE' to enable German
  * language support.
  */
-define('WPLANG', '');
-
+if ( ! defined( 'WPLANG' ) ) {
+    define('WPLANG', '');
+}
 /**
  * For developers: WordPress debugging mode.
  *


### PR DESCRIPTION
As pointed out in https://github.com/pantheon-systems/WordPress/issues/83 WPLANG is no longer used in wordpress configs. Additionally, when using tools such as wp-cli against a version of Pantheon wordpress, you get stack traces like the following:

```
PHP Notice:  Constant WPLANG already defined in phar:///usr/bin/wp-cli/php/WP_CLI/Runner.php(964) : eval()'d code on line 134
PHP Stack trace:
PHP   1. {main}() /usr/bin/wp-cli:0
PHP   2. include() /usr/bin/wp-cli:4
PHP   3. include() phar:///usr/bin/wp-cli/php/boot-phar.php:8
PHP   4. WP_CLI\bootstrap() phar:///usr/bin/wp-cli/php/wp-cli.php:23
PHP   5. WP_CLI\Bootstrap\LaunchRunner->process() phar:///usr/bin/wp-cli/php/bootstrap.php:75
PHP   6. WP_CLI\Runner->start() phar:///usr/bin/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php:23
PHP   7. WP_CLI\Runner->_run_command() phar:///usr/bin/wp-cli/php/WP_CLI/Runner.php:885
PHP   8. WP_CLI\Runner->run_command() phar:///usr/bin/wp-cli/php/WP_CLI/Runner.php:330
PHP   9. WP_CLI\Dispatcher\Subcommand->invoke() phar:///usr/bin/wp-cli/php/WP_CLI/Runner.php:323
PHP  10. call_user_func:{phar:///usr/bin/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:401}() phar:///usr/bin/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:401
PHP  11. WP_CLI\Dispatcher\CommandFactory::WP_CLI\Dispatcher\{closure}() phar:///usr/bin/wp-cli/php/WP_CLI/Dispatcher/Subcommand.php:401
PHP  12. call_user_func:{phar:///usr/bin/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:67}() phar:///usr/bin/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:67
PHP  13. DB_Command->size() phar:///usr/bin/wp-cli/php/WP_CLI/Dispatcher/CommandFactory.php:67
PHP  14. WP_CLI\Runner->load_wordpress() phar:///usr/bin/wp-cli/vendor/wp-cli/db-command/src/DB_Command.php:566
PHP  15. eval() phar:///usr/bin/wp-cli/php/WP_CLI/Runner.php:964
PHP  16. define() phar:///usr/bin/wp-cli/php/WP_CLI/Runner.php(964) : eval()'d code:134
```

This PR checks to see if WPLANG is defined before defining it. I've taken the softer approach of leaving it intact with the check because I'm unsure if there's a legacy reason it's been left in these configs. I'd be fine with a complete removal as well.

This PR does fix the errors when using wp-cli against a Pantheon WordPress code base.