### PR TITLE
Update to WordPress version 4.8.1.

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -1,35 +1,78 @@
 <?php
+// Disable WordPress ato updates
+if( ! defined('WP_AUTO_UPDATE_CORE')) {
+	define( 'WP_AUTO_UPDATE_CORE', false );
+}
+remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
+
+// Remove WordPress core update nag
+add_action('admin_menu','_pantheon_hide_update_nag');
+function _pantheon_hide_update_nag() {
+	remove_action( 'admin_notices', 'update_nag', 3 );
+}
+
+// Get the latest WordPress version
+function _pantheon_get_latest_wordpress_version() {
+	$core_updates = get_core_updates( array('dismissed' => false) );
+
+	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) ){
+		return null;
+	}
+
+	return $core_updates[0]->current;
+}
+
+// Compare the current WordPress version to the latest available
+function _pantheon_wordpress_update_available() {
+	$latest_wp_version = _pantheon_get_latest_wordpress_version();
+
+	if( null === $latest_wp_version ){
+		return false;
+	}
+
+	// include an unmodified $wp_version
+	include( ABSPATH . WPINC . '/version.php' );
+	
+	// Return true if our version is not the latest
+	return version_compare( $latest_wp_version, $wp_version, '>' );
+
+}
+
+// Replace WordPress core update nag EVERYWHERE with our own notice (use git upstream)
+function _pantheon_upstream_update_notice() {
+	// include an unmodified $wp_version
+	include( ABSPATH . WPINC . '/version.php' );
+
+	$latest_wp_version = _pantheon_get_latest_wordpress_version();
+    ?>
+    <div class="update-nag">
+		<p style="font-size: 14px; font-weight: bold; margin: 0 0 0.5em 0;">
+			WordPress <?php echo $latest_wp_version; ?> is available! Please update from <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>">your Pantheon dashboard</a>.
+		</p>
+		For details on applying updates, see the <a href="https://pantheon.io/docs/upstream-updates/" target="_blank">Applying Upstream Updates</a> documentation. <br />
+		If you need help, open a support chat on Pantheon.
+	</div>
+    <?php
+}
+
+// Register our admin notice
+add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
+function _pantheon_register_upstream_update_notice(){
+	if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && _pantheon_wordpress_update_available() ){
+		add_action( 'admin_notices', '_pantheon_upstream_update_notice' );
+	}
+}
+
 // Only in Test and Live Environments...
 if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], Array('test', 'live') ) ) {
-	//
-	// Disable Core Updates EVERYWHERE (use git upstream)
-	//
-	function _pantheon_disable_wp_updates() {
-		include ABSPATH . WPINC . '/version.php';
-		return (object) array(
-			'updates' => array(),
-			'version_checked' => $wp_version,
-			'last_checked' => time(),
-		);
-	}
 
-	add_filter( 'pre_site_transient_update_core', '_pantheon_disable_wp_updates' );
-
-	//
 	// Disable Plugin Updates
-	//
-	add_action('admin_menu','_pantheon_hide_admin_notices');
-	function _pantheon_hide_admin_notices() {
-		remove_action( 'admin_notices', 'update_nag', 3 );
-	}
-
 	remove_action( 'load-update-core.php', 'wp_update_plugins' );
 	add_filter( 'pre_site_transient_update_plugins', '_pantheon_disable_wp_updates' );
 
-	//
 	// Disable Theme Updates
-	//
 	remove_action( 'load-update-core.php', 'wp_update_themes' );
 	add_filter( 'pre_site_transient_update_themes', '_pantheon_disable_wp_updates' );
 }
+
 


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/WordPress).

**OPTIONAL** -- To create your own test site:

- Create a new WordPress site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add WordPress git@github.com:pantheon-systems/WordPress.git
  - git fetch WordPress
  - git merge WordPress/update-4.8.1
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.