### PR TITLE
Add missing _pantheon_disable_wp_updates function

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -1,5 +1,5 @@
 <?php
-// Disable WordPress ato updates
+// Disable WordPress auto updates
 if( ! defined('WP_AUTO_UPDATE_CORE')) {
 	define( 'WP_AUTO_UPDATE_CORE', false );
 }
@@ -61,6 +61,15 @@ function _pantheon_register_upstream_update_notice(){
 	if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && _pantheon_wordpress_update_available() ){
 		add_action( 'admin_notices', '_pantheon_upstream_update_notice' );
 	}
+}
+
+function _pantheon_disable_wp_updates() {
+	include ABSPATH . WPINC . '/version.php';
+	return (object) array(
+		'updates' => array(),
+		'version_checked' => $wp_version,
+		'last_checked' => time(),
+	);
 }
 
 // Only in Test and Live Environments...

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -5,8 +5,11 @@ if( ! defined('WP_AUTO_UPDATE_CORE')) {
 }
 remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
 
-// Remove WordPress core update nag
-add_action('admin_menu','_pantheon_hide_update_nag');
+// Remove the default WordPress core update nag if on Pantheon
+if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ){
+    add_action('admin_menu','_pantheon_hide_update_nag');
+}
+
 function _pantheon_hide_update_nag() {
 	remove_action( 'admin_notices', 'update_nag', 3 );
 }
@@ -58,11 +61,13 @@ function _pantheon_upstream_update_notice() {
 // Register Pantheon specific WordPress update admin notice
 add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
 function _pantheon_register_upstream_update_notice(){
+    // but only if we are on Pantheon and there is a WordPress update available
 	if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && _pantheon_wordpress_update_available() ){
 		add_action( 'admin_notices', '_pantheon_upstream_update_notice' );
 	}
 }
 
+// Return zero updates and current time as last checked time
 function _pantheon_disable_wp_updates() {
 	include ABSPATH . WPINC . '/version.php';
 	return (object) array(

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -55,7 +55,7 @@ function _pantheon_upstream_update_notice() {
     <?php
 }
 
-// Register our admin notice
+// Register Pantheon specific WordPress update admin notice
 add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
 function _pantheon_register_upstream_update_notice(){
 	if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && _pantheon_wordpress_update_available() ){
@@ -72,7 +72,8 @@ function _pantheon_disable_wp_updates() {
 	);
 }
 
-// Only in Test and Live Environments...
+// In the Test and Live environments, clear plugin/theme update notifications.
+// Users must check a dev or multidev environment for updates.
 if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], Array('test', 'live') ) ) {
 
 	// Disable Plugin Updates


### PR DESCRIPTION
Bundled with Pantheon's initial release of WordPress 4.8.1 we shipped an improvement to the update notification shown when core is out-of-date so it directs people to apply the update from their Pantheon dashboard. We inadvertently removed a required function, which this pull request fixes.

Addresses #125