### PR TITLE
Don't show WordPress update warning if the WordPress version contains src

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -19,8 +19,9 @@ function _pantheon_get_latest_wordpress_version() {
 		return null;
 	}
 
-	// We're only looking for stable releases so return null for trunk or beta version of WordPress
-	if( false === stripos($core_updates[0]->current, 'beta') || false === stripos($core_updates[0]->current, 'src') ){
+	// We're only looking for stable releases so return null for unstable versions of WordPress, such as trunk or beta
+	// Stable releases only contain numbers and periods, e.g. 4.9
+	if( 0 === preg_match('/^[\d\.]+$/', $core_updates[0]->current) ){
 		return null;
 	}
 

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -15,7 +15,7 @@ function _pantheon_hide_update_nag() {
 function _pantheon_get_latest_wordpress_version() {
 	$core_updates = get_core_updates( array('dismissed' => false) );
 
-	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) ){
+	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) || false === stripos($core_updates[0]->current, 'src') ){
 		return null;
 	}
 

--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -15,7 +15,12 @@ function _pantheon_hide_update_nag() {
 function _pantheon_get_latest_wordpress_version() {
 	$core_updates = get_core_updates( array('dismissed' => false) );
 
-	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) || false === stripos($core_updates[0]->current, 'src') ){
+	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) ){
+		return null;
+	}
+
+	// We're only looking for stable releases so return null for trunk or beta version of WordPress
+	if( false === stripos($core_updates[0]->current, 'beta') || false === stripos($core_updates[0]->current, 'src') ){
 		return null;
 	}
 


### PR DESCRIPTION
Addresses #135 