### PR TITLE
Strip '-src' from `$wp_version` for more accurate version comparison

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -37,7 +37,7 @@ function _pantheon_wordpress_update_available() {
 	include( ABSPATH . WPINC . '/version.php' );
 	
 	// Return true if our version is not the latest
-	return version_compare( $latest_wp_version, $wp_version, '>' );
+	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '>' );
 
 }
 


### PR DESCRIPTION
Fixes #135
See original conversion in #136 and discovery with tests in https://github.com/wp-cli/wp-cli/pull/4395