### PR TITLE
Use PHP 7.2 by default for WordPress sites.

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,4 +3,4 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 7.0
+php_version: 7.2


### PR DESCRIPTION
For more information on PHP versions, see https://pantheon.io/docs/php-versions/