### PR TITLE
Update to WordPress version 4.9.4.

### DIFF
--- a/wp-admin/about.php
+++ b/wp-admin/about.php
@@ -39,6 +39,24 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 					_n(
 						'<strong>Version %1$s</strong> addressed %2$s bug.',
 						'<strong>Version %1$s</strong> addressed %2$s bugs.',
+						1
+					),
+					'4.9.4',
+					number_format_i18n( 1 )
+				);
+				?>
+				<?php
+				/* translators: %s: Codex URL */
+				printf( __( 'For more information, see <a href="%s">the release notes</a>.' ), 'https://codex.wordpress.org/Version_4.9.4' );
+				?>
+			</p>
+			<p>
+				<?php
+				printf(
+					/* translators: 1: WordPress version number, 2: plural number of bugs. */
+					_n(
+						'<strong>Version %1$s</strong> addressed %2$s bug.',
+						'<strong>Version %1$s</strong> addressed %2$s bugs.',
 						34
 					),
 					'4.9.3',

--- a/wp-includes/update.php
+++ b/wp-includes/update.php
@@ -168,8 +168,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		return;
 	}
 
-	$offers          = $body['offers'];
-	$has_auto_update = false;
+	$offers = $body['offers'];
 
 	foreach ( $offers as &$offer ) {
 		foreach ( $offer as $offer_key => $value ) {
@@ -183,10 +182,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		}
 		$offer = (object) array_intersect_key( $offer, array_fill_keys( array( 'response', 'download', 'locale',
 			'packages', 'current', 'version', 'php_version', 'mysql_version', 'new_bundled', 'partial_version', 'notify_email', 'support_email', 'new_files' ), '' ) );
-
-		if ( 'autoupdate' == $offer->response ) {
-			$has_auto_update = true;
-		}
 	}
 
 	$updates = new stdClass();
@@ -208,13 +203,8 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	}
 
 	// Trigger background updates if running non-interactively, and we weren't called from the update handler.
-	if ( $doing_cron && $has_auto_update && ! doing_action( 'wp_maybe_auto_update' ) ) {
-		include_once( ABSPATH . '/wp-admin/includes/update.php' );
-
-		// Only trigger background updates if an acceptable autoupdate is on offer, avoids needless extra API calls.
-		if ( find_core_auto_update() ) {
-			do_action( 'wp_maybe_auto_update' );
-		}
+	if ( $doing_cron && ! doing_action( 'wp_maybe_auto_update' ) ) {
+		do_action( 'wp_maybe_auto_update' );
 	}
 }
 

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -4,7 +4,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '4.9.3';
+$wp_version = '4.9.4';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/WordPress).

**OPTIONAL** -- To create your own test site:

- Create a new WordPress site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add WordPress git@github.com:pantheon-systems/WordPress.git
  - git fetch WordPress
  - git merge WordPress/update-4.9.4
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.