### PR TITLE
Conditionally display the return to Pantheon button on the WordPress login form

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
@@ -3,53 +3,72 @@
  * Modify the WordPress login form for Pantheon
  */
 
-/**
- * Enqueue Pantheon login styles
- *
- * @return void
- */
-function Pantheon_Enqueue_Login_style()
-{
-    wp_enqueue_style('pantheon-login-mods', plugin_dir_url(__FILE__) . 'assets/css/return-to-pantheon-button.css', false); 
-}
+ /**
+  * Should we proceed with adding the
+  * return to Pantheon button?
+  *
+  * Only if:
+  * "RETURN_TO_PANTHEON_BUTTON" is not false,
+  * we are not on the test or live environments
+  * and we are on a Pantheon subdomain
+  */
+$show_return_to_pantheon_button = apply_filters( 'show_return_to_pantheon_button', ( 
+    ( ! defined('RETURN_TO_PANTHEON_BUTTON') || RETURN_TO_PANTHEON_BUTTON ) &&
+    ! in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) &&
+    false !== stripos( get_site_url(), 'pantheonsite.io')
+) );
 
-add_action('login_enqueue_scripts', 'Pantheon_Enqueue_Login_style', 10);
+if( $show_return_to_pantheon_button ){
 
-/**
- * Enqueue Pantheon login scripts
- *
- * @return void
- */
-function Pantheon_Enqueue_Login_script()
-{
-    wp_enqueue_script('pantheon-login-mods', plugin_dir_url(__FILE__) . 'assets/js/return-to-pantheon-button.js', array('jquery'), false, true);
-}
+    /**
+     * Enqueue Pantheon login styles
+     *
+     * @return void
+     */
+    function Pantheon_Enqueue_Login_style()
+    {
+        wp_enqueue_style('pantheon-login-mods', plugin_dir_url(__FILE__) . 'assets/css/return-to-pantheon-button.css', false); 
+    }
 
-add_action('login_enqueue_scripts', 'Pantheon_Enqueue_Login_script', 1);
+    add_action('login_enqueue_scripts', 'Pantheon_Enqueue_Login_style', 10);
 
-/**
- * Print return to Pantheon link HTML
- *
- * @return void
- */
-function Return_To_Pantheon_Button_HTML()
-{
-    $pantheon_dashboard_url = 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] . '#' . $_ENV['PANTHEON_ENVIRONMENT'];
+    /**
+     * Enqueue Pantheon login scripts
+     *
+     * @return void
+     */
+    function Pantheon_Enqueue_Login_script()
+    {
+        wp_enqueue_script('pantheon-login-mods', plugin_dir_url(__FILE__) . 'assets/js/return-to-pantheon-button.js', array('jquery'), false, true);
+    }
 
-    $pantheon_fist_icon_url = plugin_dir_url(__FILE__) . 'assets/images/pantheon-fist-icon-black.svg';
-    ?>
-    <div id="return-to-pantheon" style="display: none;">
-        <div class="left">
-                <?php _e('Login to your WordPress Site', 'pantheon'); ?>
+    add_action('login_enqueue_scripts', 'Pantheon_Enqueue_Login_script', 1);
+
+    /**
+     * Print return to Pantheon link HTML
+     *
+     * @return void
+     */
+    function Return_To_Pantheon_Button_HTML()
+    {
+        $pantheon_dashboard_url = 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] . '#' . $_ENV['PANTHEON_ENVIRONMENT'];
+
+        $pantheon_fist_icon_url = plugin_dir_url(__FILE__) . 'assets/images/pantheon-fist-icon-black.svg';
+        ?>
+        <div id="return-to-pantheon" style="display: none;">
+            <div class="left">
+                    <?php _e('Login to your WordPress Site', 'pantheon'); ?>
+            </div>
+            <div class="right">
+                <a href="<?php echo $pantheon_dashboard_url; ?>">
+                    <img class="fist-icon"  src="<?php echo $pantheon_fist_icon_url; ?>">
+                    <?php _e('Return to Pantheon', 'pantheon'); ?>
+                </a>
+            </div>
         </div>
-        <div class="right">
-            <a href="<?php echo $pantheon_dashboard_url; ?>">
-                <img class="fist-icon"  src="<?php echo $pantheon_fist_icon_url; ?>">
-                <?php _e('Return to Pantheon', 'pantheon'); ?>
-            </a>
-        </div>
-    </div>
-    <?php
-}
+        <?php
+    }
 
-add_action('login_header', 'Return_To_Pantheon_Button_HTML');
+    add_action('login_header', 'Return_To_Pantheon_Button_HTML', 10);
+
+}

--- a/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
@@ -8,14 +8,15 @@
   * return to Pantheon button?
   *
   * Only if:
-  * "RETURN_TO_PANTHEON_BUTTON" is not false,
-  * we are not on the test or live environments
-  * and we are on a Pantheon subdomain
+  * We are on a Pantheon subdomain and
+  * "RETURN_TO_PANTHEON_BUTTON" is not false
   */
 $show_return_to_pantheon_button = apply_filters( 'show_return_to_pantheon_button', ( 
     ( ! defined('RETURN_TO_PANTHEON_BUTTON') || RETURN_TO_PANTHEON_BUTTON ) &&
-    ! in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) &&
-    false !== stripos( get_site_url(), 'pantheonsite.io')
+    (
+        false !== stripos( get_site_url(), 'pantheonsite.io') ||
+        false !== stripos( $_SERVER['HTTP_HOST'], 'pantheonsite.io') 
+     )
 ) );
 
 if( $show_return_to_pantheon_button ){


### PR DESCRIPTION
By default the button is disabled for any of the following scenarios:
* The `RETURN_TO_PABTHEON_BUTTON` constant is defined and evaluates to false
* The site URL does NOT contain `pantheonsite.io`
* The `show_return_to_pantheon_button` filter value evaluates to false

Addresses #153.

Tested scenarios:

| Environment | Button Visible |
|     :---      |     :---:      |
| [multidev](https://return-btn-wp-microsite.pantheonsite.io/wp-login.php) | Y |
| [dev](https://dev-wp-microsite.pantheonsite.io/wp-login.php) | Y |
| [test](https://test-wp-microsite.pantheonsite.io/wp-login.php) | Y |
| [live](https://live-wp-microsite.pantheonsite.io/wp-login.php) | Y |
| [scalep.io](https://scalewp.io/wp-login.php) | N |