### PR TITLE
[OTTO-360] Specify correct UTF-8 compliant charset

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -38,7 +38,7 @@ else:
     define('DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT']);
 
     /** Database Charset to use in creating database tables. */
-    define('DB_CHARSET', 'utf8');
+    define('DB_CHARSET', 'utf8mb4');
 
     /** The Database Collate type. Don't change this if in doubt. */
     define('DB_COLLATE', '');


### PR DESCRIPTION
Closes: #160 
Reference: https://github.com/pantheon-systems/documentation/issues/3693

utf8 is an outdated charset from MySQL that doesn't actually cover all UTF-8 characters. Our documentation already suggests that new sites use utf8mb4, but this seems to indicate otherwise.