### PR TITLE
Set $_SERVER['HTTPS']

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -74,6 +74,7 @@ else:
         // content warnings.
         if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON') {
             $scheme = 'https';
+	    $_SERVER['HTTPS'] = 'on';
         }
         define('WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST']);
         define('WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST']);

--- a/wp-config.php
+++ b/wp-config.php
@@ -74,7 +74,7 @@ else:
         // content warnings.
         if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON') {
             $scheme = 'https';
-	    $_SERVER['HTTPS'] = 'on';
+            $_SERVER['HTTPS'] = 'on';
         }
         define('WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST']);
         define('WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST']);


### PR DESCRIPTION
Set `$_SERVER['HTTPS']` to `on` when HTTPS is detected in `wp-config.php`. Closes #166