### PR TITLE
Add Try Gutenberg panel modifications

### DIFF
--- a/wp-content/mu-plugins/pantheon.php
+++ b/wp-content/mu-plugins/pantheon.php
@@ -13,5 +13,6 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) :
 require_once( 'pantheon/pantheon-page-cache.php' );
 require_once( 'pantheon/pantheon-updates.php' );
 require_once( 'pantheon/pantheon-login-form-mods.php' );
+require_once( 'pantheon/pantheon-try-gutenberg-mods.php' );
 
 endif; # Ensuring that this is on Pantheon

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -7,7 +7,7 @@
   * We are on a Pantheon subdomain and
   * "RETURN_TO_PANTHEON_BUTTON" is not false
   */
-$mod_try_gutenberg = apply_filters( 'show_pantheon_try_gutenberg_mods', ( ! defined('DISABLE_PANTHEON_TRY_GUTENBERG_MODS') || DISABLE_PANTHEON_TRY_GUTENBERG_MODS ) );
+$mod_try_gutenberg = apply_filters( 'show_pantheon_try_gutenberg_mods', ( ! defined('DISABLE_PANTHEON_TRY_GUTENBERG_MODS') || ! DISABLE_PANTHEON_TRY_GUTENBERG_MODS ) );
 
 function _pantheon_try_gutenberg_host_link(){
 ?>

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -1,62 +1,87 @@
 <?php
 /**
-  * Should we proceed with adding the
-  * return to Pantheon button?
-  *
-  * Only if:
-  * We are on a Pantheon subdomain and
-  * "RETURN_TO_PANTHEON_BUTTON" is not false
-  */
+ * Should we proceed with adding the
+ * Try Gutenberg panel mods?
+*/
 $mod_try_gutenberg = apply_filters( 'show_pantheon_try_gutenberg_mods', ( ! defined('DISABLE_PANTHEON_TRY_GUTENBERG_MODS') || ! DISABLE_PANTHEON_TRY_GUTENBERG_MODS ) );
 
-function _pantheon_try_gutenberg_host_link(){
-?>
-<style type="text/css">
-    .try-gutenberg-panel .try-gutenberg-panel-column:not(.try-gutenberg-panel-image-column) {
-        grid-template-rows: auto;
-    }
-    .try-gutenberg-panel .host-link {
-        font-weight: bold;
-    }
-</style>
-<p>
-<?php
-printf(
- 	/* translators: Link to https://pantheon.io/gutenberg */
- 	__( '<a href="%s" class="host-link">Learn about Gutenberg on Pantheon</a>' ),
- 	__( 'https://pantheon.io/gutenberg' )
-);
-?>
-</p>
-<?php    
+/**
+ * Modify the learn more Gutenberg link
+ * to go to the Pantheon Gutenberg page
+ * rather than WordPress.org
+ *
+ * @param string $learn_more
+ * @return string
+ */
+function _pantheon_try_gutenberg_host_link( $learn_more ){
+
+    $style_mods = '<style type="text/css">.try-gutenberg-panel .try-gutenberg-panel-column:not(.try-gutenberg-panel-image-column) {grid-template-rows: auto;}</style>';
+
+    return $style_mods . sprintf(
+        /* translators: Link to https://pantheon.io/gutenberg */
+        __( '<a href="%s">Learn more about Gutenberg</a>.' ),
+        __( 'https://pantheon.io/gutenberg' )
+    );
+
 }
 
+/**
+ * Only add the filter if we should
+ * be adding Pantheon modifications
+ * to the Try Gutenberg panel
+ */
 if( true === $mod_try_gutenberg ){
-    add_action( 'try_gutenberg_after_install_button', '_pantheon_try_gutenberg_host_link');
+    add_filter( 'try_gutenberg_learn_more_link', '_pantheon_try_gutenberg_host_link');
 }
 
+/**
+ * Add a Pantheon specific section to
+ * the end of the Try Gutenberg panel
+ *
+ * @return void
+ */
 function _pantheon_try_gutenberg_append_warning(){
 ?>
 <style type="text/css">
     .try-gutenberg-panel .pantheon-notice {
-        color: #2C3539;
-        border-left: solid 5px #2C3539;
-        padding: 0 1em;
-        margin: 0.5em 0;
+        padding: 0 1em 0.5em;
+        margin: 0.5em 0 2em;
+        border: 1px solid #ccc;
+        border-left: solid 4px #5bc0de;
+        border-radius: 4px;
     }
 </style>
 <div class="try-gutenberg-panel-content"><div class="pantheon-notice">
+<h3>
+<?php __('Gutenberg on Pantheon'); ?>
+</h3>
+<p>
+<?php
+printf(
+ 	/* translators: Link to https://pantheon.io/gutenberg */
+ 	__( 'Pantheon offers resources, such as webinars, on getting the most out of Gutenberg. <a href="%s">Learn about Gutenberg on Pantheon</a>.' ),
+ 	__( 'https://pantheon.io/gutenberg' )
+);
+?>
+</p>
+<p>
 <?php
 printf(
  	/* translators: Link to https://pantheon.io/docs/pantheon-workflow/ */
- 	__( '<h3>New to Pantheon?</h3><p>Remember to install Gutenberg in the Dev environment and use <a href="%s">the Pantheon workflow</a> when ready to deploy to Test or Live.</p>' ),
+ 	__( 'Just like any code change, Gutenberg should be added, tested and deployed using <a href="%s">the Pantheon workflow</a>.' ),
  	__( 'https://pantheon.io/docs/pantheon-workflow/' )
 );
 ?>
+</p>
 </div></div>
 <?php    
 }
 
+/**
+ * Only add the action if we should
+ * be adding Pantheon modifications
+ * to the Try Gutenberg panel
+ */
 if( true === $mod_try_gutenberg ){
     add_action( 'try_gutenberg_panel', '_pantheon_try_gutenberg_append_warning', 99);
 }

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -19,7 +19,7 @@ function _pantheon_try_gutenberg_host_link( $learn_more ){
 
     return $style_mods . sprintf(
         /* translators: Link to https://pantheon.io/gutenberg */
-        __( '<a href="%s">Learn more about Gutenberg</a>.' ),
+        __( '<a href="%s">Learn more about Gutenberg on Pantheon</a>.' ),
         __( 'https://pantheon.io/gutenberg' )
     );
 

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -1,0 +1,54 @@
+<?php
+function _pantheon_try_gutenberg_host_link(){
+?>
+<style type="text/css">
+    .try-gutenberg-panel .try-gutenberg-panel-column:not(.try-gutenberg-panel-image-column) {
+        grid-template-rows: auto;
+    }
+    .try-gutenberg-panel .host-link {
+        font-weight: bold;
+    }
+    .try-gutenberg-action > p:first-of-type {
+        display: none;
+    }
+</style>
+<p>
+<?php
+printf(
+ 	/* translators: Link to https://pantheon.io/gutenberg */
+ 	__( '<a href="%s" class="host-link">Learn about Gutenberg on Pantheon</a>' ),
+ 	__( 'https://pantheon.io/gutenberg' )
+);
+?>
+</p>
+<?php    
+}
+
+add_action( 'try_gutenberg_after_install_button', '_pantheon_try_gutenberg_host_link');
+
+function _pantheon_try_gutenberg_append_warning(){
+?>
+<style type="text/css">
+    .try-gutenberg-panel .pantheon-notice {
+        font-size: 16px;
+        color: #2C3539;
+        border-left: solid 5px #2C3539;
+        padding: 1em;
+        margin: 0.5em 0;
+    }
+</style>
+<div class="try-gutenberg-panel-content"><div class="pantheon-notice">
+<?php
+printf(
+ 	/* translators: Link to https://pantheon.io/docs/pantheon-workflow/ */
+ 	__( 'We encourage you to test Gutenberg on Pantheon in a safe way. Please remember, like any code change, installing Gutenberg needs to go through <a href="%s">the Pantheon workflow</a>.' ),
+ 	__( 'https://pantheon.io/docs/pantheon-workflow/' )
+);
+?>
+</div></div>
+<?php    
+}
+
+// if( in_array($_ENV['PANTHEON_ENVIRONMENT'], array('test', 'live') ) ){
+    add_action( 'try_gutenberg_panel', '_pantheon_try_gutenberg_append_warning', 99);
+// }

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -41,7 +41,7 @@ function _pantheon_try_gutenberg_append_warning(){
     .try-gutenberg-panel .pantheon-notice {
         color: #2C3539;
         border-left: solid 5px #2C3539;
-        padding: 1em;
+        padding: 0 1em;
         margin: 0.5em 0;
     }
 </style>

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -8,9 +8,6 @@ function _pantheon_try_gutenberg_host_link(){
     .try-gutenberg-panel .host-link {
         font-weight: bold;
     }
-    .try-gutenberg-action > p:first-of-type {
-        display: none;
-    }
 </style>
 <p>
 <?php

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -27,7 +27,6 @@ function _pantheon_try_gutenberg_append_warning(){
 ?>
 <style type="text/css">
     .try-gutenberg-panel .pantheon-notice {
-        font-size: 16px;
         color: #2C3539;
         border-left: solid 5px #2C3539;
         padding: 1em;
@@ -38,7 +37,7 @@ function _pantheon_try_gutenberg_append_warning(){
 <?php
 printf(
  	/* translators: Link to https://pantheon.io/docs/pantheon-workflow/ */
- 	__( 'We encourage you to test Gutenberg on Pantheon in a safe way. Please remember, like any code change, installing Gutenberg needs to go through <a href="%s">the Pantheon workflow</a>.' ),
+ 	__( '<h3>New to Pantheon?</h3><p>Remember to install Gutenberg in the Dev environment and use <a href="%s">the Pantheon workflow</a> when ready to deploy to Test or Live.</p>' ),
  	__( 'https://pantheon.io/docs/pantheon-workflow/' )
 );
 ?>

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -1,11 +1,5 @@
 <?php
 /**
- * Should we proceed with adding the
- * Try Gutenberg panel mods?
-*/
-$mod_try_gutenberg = apply_filters( 'show_pantheon_try_gutenberg_mods', ( ! defined('DISABLE_PANTHEON_TRY_GUTENBERG_MODS') || ! DISABLE_PANTHEON_TRY_GUTENBERG_MODS ) );
-
-/**
  * Modify the learn more Gutenberg link
  * to go to the Pantheon Gutenberg page
  * rather than WordPress.org
@@ -30,7 +24,7 @@ function _pantheon_try_gutenberg_host_link( $learn_more ){
  * be adding Pantheon modifications
  * to the Try Gutenberg panel
  */
-if( true === $mod_try_gutenberg ){
+if( ( ! defined('DISABLE_PANTHEON_TRY_GUTENBERG_MODS') || ! DISABLE_PANTHEON_TRY_GUTENBERG_MODS ) ){
     add_filter( 'try_gutenberg_learn_more_link', '_pantheon_try_gutenberg_host_link');
 }
 
@@ -82,6 +76,6 @@ printf(
  * be adding Pantheon modifications
  * to the Try Gutenberg panel
  */
-if( true === $mod_try_gutenberg ){
+if( ( ! defined('DISABLE_PANTHEON_TRY_GUTENBERG_MODS') || ! DISABLE_PANTHEON_TRY_GUTENBERG_MODS ) ){
     add_action( 'try_gutenberg_panel', '_pantheon_try_gutenberg_append_warning', 99);
 }

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -1,4 +1,14 @@
 <?php
+/**
+  * Should we proceed with adding the
+  * return to Pantheon button?
+  *
+  * Only if:
+  * We are on a Pantheon subdomain and
+  * "RETURN_TO_PANTHEON_BUTTON" is not false
+  */
+$mod_try_gutenberg = apply_filters( 'show_pantheon_try_gutenberg_mods', true);
+
 function _pantheon_try_gutenberg_host_link(){
 ?>
 <style type="text/css">
@@ -21,7 +31,9 @@ printf(
 <?php    
 }
 
-add_action( 'try_gutenberg_after_install_button', '_pantheon_try_gutenberg_host_link');
+if( true === $mod_try_gutenberg ){
+    add_action( 'try_gutenberg_after_install_button', '_pantheon_try_gutenberg_host_link');
+}
 
 function _pantheon_try_gutenberg_append_warning(){
 ?>
@@ -45,6 +57,6 @@ printf(
 <?php    
 }
 
-// if( in_array($_ENV['PANTHEON_ENVIRONMENT'], array('test', 'live') ) ){
+if( true === $mod_try_gutenberg ){
     add_action( 'try_gutenberg_panel', '_pantheon_try_gutenberg_append_warning', 99);
-// }
+}

--- a/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-try-gutenberg-mods.php
@@ -7,7 +7,7 @@
   * We are on a Pantheon subdomain and
   * "RETURN_TO_PANTHEON_BUTTON" is not false
   */
-$mod_try_gutenberg = apply_filters( 'show_pantheon_try_gutenberg_mods', true);
+$mod_try_gutenberg = apply_filters( 'show_pantheon_try_gutenberg_mods', ( ! defined('DISABLE_PANTHEON_TRY_GUTENBERG_MODS') || DISABLE_PANTHEON_TRY_GUTENBERG_MODS ) );
 
 function _pantheon_try_gutenberg_host_link(){
 ?>


### PR DESCRIPTION
* Replace the _Learn more about Gutenberg_ link to [wordpress.org/gutenberg](https://wordpress.org/gutenberg/) with _Learn about Gutenberg on Pantheon_ linking to [pantheon.io/gutenberg](https://pantheon.io/gutenberg)
* Add a message encouraging users to test Gutenberg in a safe way on Pantheon linking to [pantheon.io/docs/pantheon-workflow](https://pantheon.io/docs/pantheon-workflow/)

The panel (as of 7/25/18) before modifications:
![try-gutenberg-no-mods-live-desktop](https://user-images.githubusercontent.com/2133004/43228887-bc828194-9017-11e8-9fe4-b899833e22df.png)
![try-gutenberg-no-mods-live-mobile](https://user-images.githubusercontent.com/2133004/43228888-bc986496-9017-11e8-8b7b-d54e524e9df1.png)
![try-gutenberg-no-mods-sftp-mode-desktop](https://user-images.githubusercontent.com/2133004/43228889-bcb4b81c-9017-11e8-8a7e-78bd8bc376b4.png)
![try-gutenberg-no-mods-sftp-mode-mobile](https://user-images.githubusercontent.com/2133004/43228890-bcce178a-9017-11e8-98cd-3dbad228bf94.png)