### PR TITLE
Check if HTTP_HOST is set before reading it

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
@@ -15,7 +15,7 @@ $show_return_to_pantheon_button = apply_filters( 'show_return_to_pantheon_button
     ( ! defined('RETURN_TO_PANTHEON_BUTTON') || RETURN_TO_PANTHEON_BUTTON ) &&
     (
         false !== stripos( get_site_url(), 'pantheonsite.io') ||
-        false !== stripos( $_SERVER['HTTP_HOST'], 'pantheonsite.io') 
+        ( isset( $_SERVER['HTTP_HOST'] ) && false !== stripos( $_SERVER['HTTP_HOST'], 'pantheonsite.io') )
      )
 ) );
 


### PR DESCRIPTION
I noticed an issue when invoking WP-CLI on a Lando-based Pantheon install:

```
$ lando wp plugin update query-monitor
PHP Notice:  Undefined index: HTTP_HOST in /app/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php on line 18
Notice: Undefined index: HTTP_HOST in /app/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php on line 18
```

This fixes the issue by ensuring `$_SERVER['HTTP_HOST']` is set before accessing it.