### PR TITLE
Respect custom `login_message` filter value when present

### DIFF
--- a/wp-content/mu-plugins/pantheon/assets/css/return-to-pantheon-button.css
+++ b/wp-content/mu-plugins/pantheon/assets/css/return-to-pantheon-button.css
@@ -12,6 +12,7 @@
 #return-to-pantheon .left {
     font-size: 16px;
     font-weight: 400;
+    line-height: 1.4;
 }
 
 #return-to-pantheon a{
@@ -26,6 +27,7 @@
     font-size: 12px;
     text-align: center;
     border-radius: 10px;
+    min-width: 130px;
 }
 
 #return-to-pantheon a:hover {

--- a/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
@@ -55,14 +55,20 @@ if( $show_return_to_pantheon_button ){
         $pantheon_dashboard_url = 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] . '#' . $_ENV['PANTHEON_ENVIRONMENT'];
 
         $pantheon_fist_icon_url = plugin_dir_url(__FILE__) . 'assets/images/pantheon-fist-icon-black.svg';
+
+        $login_message = apply_filters( 'login_message', __( 'Login to your WordPress site', 'pantheon' ) );
+
+        // Prevent WordPress core from outputting additional login messages.
+        remove_all_filters( 'login_message' );
+
         ?>
         <div id="return-to-pantheon" style="display: none;">
             <div class="left">
-                    <?php _e('Login to your WordPress Site', 'pantheon'); ?>
+                    <?php echo $login_message; ?>
             </div>
             <div class="right">
-                <a href="<?php echo $pantheon_dashboard_url; ?>">
-                    <img class="fist-icon"  src="<?php echo $pantheon_fist_icon_url; ?>">
+                <a href="<?php echo esc_url( $pantheon_dashboard_url ); ?>">
+                    <img class="fist-icon"  src="<?php echo esc_url( $pantheon_fist_icon_url ); ?>">
                     <?php _e('Return to Pantheon', 'pantheon'); ?>
                 </a>
             </div>


### PR DESCRIPTION
Originally #193

If user code filters `login_message`, then the included value will display next to the "Return to Pantheon" button:

**Desktop**
<img width="611" alt="image" src="https://user-images.githubusercontent.com/36432/61712786-f64d0900-ad0b-11e9-8da7-127a4235e172.png">

**Mobile**
<img width="531" alt="image" src="https://user-images.githubusercontent.com/36432/61712857-1aa8e580-ad0c-11e9-88dc-e74b523860f6.png">
