### PR TITLE
Introduce a new filter to allow the Pantheon WordPress login text modified

### DIFF
--- a/wp-content/mu-plugins/pantheon/assets/css/return-to-pantheon-button.css
+++ b/wp-content/mu-plugins/pantheon/assets/css/return-to-pantheon-button.css
@@ -12,6 +12,7 @@
 #return-to-pantheon .left {
     font-size: 16px;
     font-weight: 400;
+    line-height: 1.4;
 }
 
 #return-to-pantheon a{
@@ -26,6 +27,7 @@
     font-size: 12px;
     text-align: center;
     border-radius: 10px;
+    min-width: 130px
 }
 
 #return-to-pantheon a:hover {

--- a/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-login-form-mods.php
@@ -55,14 +55,15 @@ if( $show_return_to_pantheon_button ){
         $pantheon_dashboard_url = 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] . '#' . $_ENV['PANTHEON_ENVIRONMENT'];
 
         $pantheon_fist_icon_url = plugin_dir_url(__FILE__) . 'assets/images/pantheon-fist-icon-black.svg';
+        $login_message = apply_filters( 'pantheon_wp_login_text', __('Login to your WordPress Site', 'pantheon') );
         ?>
         <div id="return-to-pantheon" style="display: none;">
             <div class="left">
-                    <?php _e('Login to your WordPress Site', 'pantheon'); ?>
+                    <?php echo $login_message; ?>
             </div>
             <div class="right">
-                <a href="<?php echo $pantheon_dashboard_url; ?>">
-                    <img class="fist-icon"  src="<?php echo $pantheon_fist_icon_url; ?>">
+                <a href="<?php echo esc_url( $pantheon_dashboard_url ); ?>">
+                    <img class="fist-icon"  src="<?php echo esc_url( $pantheon_fist_icon_url ); ?>">
                     <?php _e('Return to Pantheon', 'pantheon'); ?>
                 </a>
             </div>


### PR DESCRIPTION
To customize the explanatory text displayed on the Login screen, add the following filter to your theme's `functions.php` file or a mu-plugin:

```php
add_filter( 'pantheon_wp_login_text', function() {
	return 'This is my custom and really long login message';
});
```


<img width="625" alt="image" src="https://user-images.githubusercontent.com/36432/61713237-ed106c00-ad0c-11e9-947e-0a340b2edfae.png">

From #193
Fixes #192
