### PR TITLE
Smarter WordPress Dashboard Custom Upstream Update Notifications

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -12,48 +12,51 @@ if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ){
 
 function _pantheon_hide_update_nag() {
 	remove_action( 'admin_notices', 'update_nag', 3 );
-}
-
-// Get the latest WordPress version
-function _pantheon_get_latest_wordpress_version() {
-	$core_updates = get_core_updates( array('dismissed' => false) );
-
-	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) ){
-		return null;
-	}
-
-	return $core_updates[0]->current;
+	remove_action( 'network_admin_notices', 'update_nag', 3 );
 }
 
 // Compare the current WordPress version to the latest available
 function _pantheon_wordpress_update_available() {
-	$latest_wp_version = _pantheon_get_latest_wordpress_version();
 
-	if( null === $latest_wp_version ){
+	if ( ! function_exists( 'pantheon_curl' ) ) {
 		return false;
 	}
+	$data = _pantheon_curl_cached( 'https://api.live.getpantheon.com/sites/self/code-upstream-updates' );
+	if ( ! empty( $data['dev'] ) && isset( $data['dev']['is_up_to_date_with_upstream'] ) ) {
+		return $data['dev']['is_up_to_date_with_upstream'] ? false : true;
+	}
+	return false;
+}
 
-	// include an unmodified $wp_version
-	include( ABSPATH . WPINC . '/version.php' );
-
-	// Return true if our version is not the latest
-	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '>' );
-
+function _pantheon_curl_cached( $api_url ) {
+	$cache_key   = 'pantheon_curl_' . md5( $api_url );
+	$cache_value = get_transient( $cache_key );
+	if ( false !== $cache_value ) {
+		return $cache_value;
+	}
+	$api_response = pantheon_curl( $api_url, null, 8443 );
+	$data = $api_response ? json_decode( $api_response['body'], true ) : [];
+	set_transient( $cache_key, $data, 2 * MINUTE_IN_SECONDS );
+	return $data;
 }
 
 // Replace WordPress core update nag EVERYWHERE with our own notice (use git upstream)
 function _pantheon_upstream_update_notice() {
-	// include an unmodified $wp_version
-	include( ABSPATH . WPINC . '/version.php' );
+	$update_type = 'new WordPress version';
+	$update_help = 'If you need help, open a support chat on Pantheon.';
+	$data = _pantheon_curl_cached( 'https://api.live.getpantheon.com/sites/self/code-upstream-updates' );
+	if ( ! empty( $data['remote_url'] ) && false === stripos( $data['remote_url'], '/pantheon-systems/' ) ) {
+		$update_type = 'Pantheon Custom Upstream update';
+		$update_help = 'If you need help, contact an administrator for your Pantheon organization.';
+	}
 
-	$latest_wp_version = _pantheon_get_latest_wordpress_version();
     ?>
     <div class="update-nag">
 		<p style="font-size: 14px; font-weight: bold; margin: 0 0 0.5em 0;">
-			WordPress <?php echo $latest_wp_version; ?> is available! Please update from <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>">your Pantheon dashboard</a>.
+			A <?php echo $update_type; ?> is available! Please update from <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>">your Pantheon dashboard</a>.
 		</p>
 		For details on applying updates, see the <a href="https://pantheon.io/docs/upstream-updates/" target="_blank">Applying Upstream Updates</a> documentation. <br />
-		If you need help, open a support chat on Pantheon.
+		<?php echo $update_help; ?>
 	</div>
     <?php
 }


### PR DESCRIPTION
Originally #140

In a local environment, the standard WordPress update nag will show if there's a WordPress update available.

In Pantheon environments, the standard WordPress update nag is removed. The Pantheon update nag will only appear if `pantheon_curl()` is available and returns `is_up_to_date_with_upstream=false`.

However, because we don't have the "version" of the upstream, I've made the message more generic:

<img width="891" alt="image" src="https://user-images.githubusercontent.com/36432/62951619-1b7ae780-bd9f-11e9-91ed-2916f9738186.png">
