### PR TITLE
Update to WordPress 5.2.4. For more information, see https://wordpress.org/news/2019/10/wordpress-5-2-4-security-release/

### DIFF
--- a/wp-admin/about.php
+++ b/wp-admin/about.php
@@ -53,7 +53,27 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 			<p>
 				<?php
 				printf(
-					/* translators: 1: WordPress version number, 2: plural number of bugs. More than one security issue. */
+					/* translators: %s: WordPress version number */
+					__( '<strong>Version %s</strong> addressed some security issues.' ),
+					'5.2.4'
+				);
+				?>
+				<?php
+				printf(
+				/* translators: %s: HelpHub URL */
+					__( 'For more information, see <a href="%s">the release notes</a>.' ),
+					sprintf(
+					/* translators: %s: WordPress version */
+						esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+						sanitize_title( '5.2.4' )
+					)
+				);
+				?>
+			</p>
+			<p>
+				<?php
+				printf(
+				/* translators: 1: WordPress version number, 2: plural number of bugs. More than one security issue. */
 					_n(
 						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug.',
 						'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
@@ -65,10 +85,10 @@ include( ABSPATH . 'wp-admin/admin-header.php' );
 				?>
 				<?php
 				printf(
-					/* translators: %s: HelpHub URL */
+				/* translators: %s: HelpHub URL */
 					__( 'For more information, see <a href="%s">the release notes</a>.' ),
 					sprintf(
-						/* translators: %s: WordPress version */
+					/* translators: %s: WordPress version */
 						esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
 						sanitize_title( '5.2.3' )
 					)

--- a/wp-includes/class-wp-query.php
+++ b/wp-includes/class-wp-query.php
@@ -538,7 +538,6 @@ class WP_Query {
 			'attachment',
 			'attachment_id',
 			'name',
-			'static',
 			'pagename',
 			'page_id',
 			'second',
@@ -802,7 +801,7 @@ class WP_Query {
 			// If year, month, day, hour, minute, and second are set, a single
 			// post is being queried.
 			$this->is_single = true;
-		} elseif ( '' != $qv['static'] || '' != $qv['pagename'] || ! empty( $qv['page_id'] ) ) {
+		} elseif ( '' != $qv['pagename'] || ! empty( $qv['page_id'] ) ) {
 			$this->is_page   = true;
 			$this->is_single = false;
 		} else {

--- a/wp-includes/class-wp.php
+++ b/wp-includes/class-wp.php
@@ -14,7 +14,7 @@ class WP {
 	 * @since 2.0.0
 	 * @var string[]
 	 */
-	public $public_query_vars = array( 'm', 'p', 'posts', 'w', 'cat', 'withcomments', 'withoutcomments', 's', 'search', 'exact', 'sentence', 'calendar', 'page', 'paged', 'more', 'tb', 'pb', 'author', 'order', 'orderby', 'year', 'monthnum', 'day', 'hour', 'minute', 'second', 'name', 'category_name', 'tag', 'feed', 'author_name', 'static', 'pagename', 'page_id', 'error', 'attachment', 'attachment_id', 'subpost', 'subpost_id', 'preview', 'robots', 'taxonomy', 'term', 'cpage', 'post_type', 'embed' );
+	public $public_query_vars = array( 'm', 'p', 'posts', 'w', 'cat', 'withcomments', 'withoutcomments', 's', 'search', 'exact', 'sentence', 'calendar', 'page', 'paged', 'more', 'tb', 'pb', 'author', 'order', 'orderby', 'year', 'monthnum', 'day', 'hour', 'minute', 'second', 'name', 'category_name', 'tag', 'feed', 'author_name', 'pagename', 'page_id', 'error', 'attachment', 'attachment_id', 'subpost', 'subpost_id', 'preview', 'robots', 'taxonomy', 'term', 'cpage', 'post_type', 'embed' );
 
 	/**
 	 * Private query variables.

--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -1787,6 +1787,11 @@ function wp_mkdir_p( $target ) {
 		return @is_dir( $target );
 	}
 
+	// Do not allow path traversals.
+	if ( false !== strpos( $target, '../' ) || false !== strpos( $target, '..' . DIRECTORY_SEPARATOR ) ) {
+		return false;
+	}
+
 	// We need to find the permissions of the parent folder that exists and inherit that.
 	$target_parent = dirname( $target );
 	while ( '.' != $target_parent && ! is_dir( $target_parent ) && dirname( $target_parent ) !== $target_parent ) {

--- a/wp-includes/http.php
+++ b/wp-includes/http.php
@@ -555,7 +555,7 @@ function wp_http_validate_url( $url ) {
 		} else {
 			$ip = gethostbyname( $host );
 			if ( $ip === $host ) { // Error condition for gethostbyname()
-				$ip = false;
+				return false;
 			}
 		}
 		if ( $ip ) {

--- a/wp-includes/pluggable.php
+++ b/wp-includes/pluggable.php
@@ -1092,7 +1092,7 @@ if ( ! function_exists( 'check_admin_referer' ) ) :
 	 *                   0-12 hours ago, 2 if the nonce is valid and generated between 12-24 hours ago.
 	 */
 	function check_admin_referer( $action = -1, $query_arg = '_wpnonce' ) {
-		if ( -1 == $action ) {
+		if ( -1 === $action ) {
 			_doing_it_wrong( __FUNCTION__, __( 'You should specify a nonce action to be verified by using the first parameter.' ), '3.2.0' );
 		}
 
@@ -1111,7 +1111,7 @@ if ( ! function_exists( 'check_admin_referer' ) ) :
 		 */
 		do_action( 'check_admin_referer', $action, $result );
 
-		if ( ! $result && ! ( -1 == $action && strpos( $referer, $adminurl ) === 0 ) ) {
+		if ( ! $result && ! ( -1 === $action && strpos( $referer, $adminurl ) === 0 ) ) {
 			wp_nonce_ays( $action );
 			die();
 		}
@@ -1400,6 +1400,7 @@ if ( ! function_exists( 'wp_validate_redirect' ) ) :
 			$path = '';
 			if ( ! empty( $_SERVER['REQUEST_URI'] ) ) {
 				$path = dirname( parse_url( 'http://placeholder' . $_SERVER['REQUEST_URI'], PHP_URL_PATH ) . '?' );
+				$path = wp_normalize_path( $path );
 			}
 			$location = '/' . ltrim( $path . '/', '/' ) . $location;
 		}

--- a/wp-includes/rest-api.php
+++ b/wp-includes/rest-api.php
@@ -587,6 +587,8 @@ function rest_send_cors_headers( $value ) {
 		header( 'Access-Control-Allow-Origin: ' . $origin );
 		header( 'Access-Control-Allow-Methods: OPTIONS, GET, POST, PUT, PATCH, DELETE' );
 		header( 'Access-Control-Allow-Credentials: true' );
+		header( 'Vary: Origin', false );
+	} elseif ( ! headers_sent() && 'GET' === $_SERVER['REQUEST_METHOD'] && ! is_user_logged_in() ) {
 		header( 'Vary: Origin' );
 	}
 

--- a/wp-includes/script-loader.php
+++ b/wp-includes/script-loader.php
@@ -1178,8 +1178,6 @@ function wp_default_scripts( &$scripts ) {
 		)
 	);
 
-	$scripts->add( 'wp-sanitize', "/wp-includes/js/wp-sanitize$suffix.js", array( 'jquery' ), false, 1 );
-
 	$scripts->add( 'wp-backbone', "/wp-includes/js/wp-backbone$suffix.js", array( 'backbone', 'wp-util' ), false, 1 );
 
 	$scripts->add( 'revisions', "/wp-admin/js/revisions$suffix.js", array( 'wp-backbone', 'jquery-ui-slider', 'hoverIntent' ), false, 1 );

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -13,7 +13,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '5.2.3';
+$wp_version = '5.2.4';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
Update from WordPress 5.2.3 to WordPress 5.2.4.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/WordPress), and then visit the test site and confirm that the correct version of WordPress was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new WordPress site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add wp git@github.com:pantheon-systems/WordPress.git
    - git fetch wp
    - git merge wp/update-5.2.4
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
