### PR TITLE
[BUGS-2808] Update notification improvements

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -1,12 +1,13 @@
 <?php
-// Disable WordPress auto updates
-if( ! defined('WP_AUTO_UPDATE_CORE')) {
-	define( 'WP_AUTO_UPDATE_CORE', false );
-}
-remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
-
-// Remove the default WordPress core update nag if on Pantheon
+// If on Pantheon
 if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ){
+	// Disable WordPress auto updates
+	if( ! defined('WP_AUTO_UPDATE_CORE')) {
+		define( 'WP_AUTO_UPDATE_CORE', false );
+	}
+
+	remove_action( 'wp_maybe_auto_update', 'wp_maybe_auto_update' );
+	// Remove the default WordPress core update nag
     add_action('admin_menu','_pantheon_hide_update_nag');
 }
 
@@ -15,17 +16,70 @@ function _pantheon_hide_update_nag() {
 	remove_action( 'network_admin_notices', 'update_nag', 3 );
 }
 
-// Compare the current WordPress version to the latest available
+// Get the latest WordPress version
+function _pantheon_get_latest_wordpress_version() {
+	$core_updates = get_core_updates( array('dismissed' => false) );
+
+	if( ! is_array($core_updates) || empty($core_updates) || ! property_exists($core_updates[0], 'current' ) ){
+		return null;
+	}
+
+	return $core_updates[0]->current;
+}
+
+// Check if WordPress core is at the latest version.
+function _pantheon_is_wordpress_core_latest() {
+	$latest_wp_version = _pantheon_get_latest_wordpress_version();
+
+	if( null === $latest_wp_version ){
+		return true;
+	}
+
+	// include an unmodified $wp_version
+	include( ABSPATH . WPINC . '/version.php' );
+
+	// Return true if our version is the latest
+	return version_compare( str_replace( '-src', '', $latest_wp_version ), str_replace( '-src', '', $wp_version ), '=' );
+
+}
+
+// Return upstream's org and repository names, or false if not a custom upstream
+// (i.e. Pantheon WordPress or wordpress-network )
+function _pantheon_fetch_custom_upstream_info() {
+	$data = _pantheon_curl_cached( 'https://api.live.getpantheon.com/sites/self/code-upstream-updates' );
+	if ( empty( $data['remote_url'] ) || false !== stripos( $data['remote_url'], '/pantheon-systems/' )) {
+		// remote_url was missing or this is not a custom upstream
+		return false;
+	}
+	$url_path = ltrim( parse_url( $data['remote_url'], PHP_URL_PATH ), '/' );
+	return str_replace( '.git', '', $url_path );
+}
+
+// Check if Pantheon upstream updates are available.
 function _pantheon_wordpress_update_available() {
 
 	if ( ! function_exists( 'pantheon_curl' ) ) {
 		return false;
 	}
-	$data = _pantheon_curl_cached( 'https://api.live.getpantheon.com/sites/self/code-upstream-updates' );
-	if ( ! empty( $data['dev'] ) && isset( $data['dev']['is_up_to_date_with_upstream'] ) ) {
-		return $data['dev']['is_up_to_date_with_upstream'] ? false : true;
+
+	/**
+	 * If the site is using the default WordPress upstream and
+	 * WordPress is up to date, do not show the update notice
+	 */
+	if( ! _pantheon_fetch_custom_upstream_info() && _pantheon_is_wordpress_core_latest() ) {
+		return false;
 	}
-	return false;
+
+	$upstream_updates_api_url = 'https://api.live.getpantheon.com/sites/self/code-upstream-updates';
+	if ( 'dev' != $_ENV['PANTHEON_ENVIRONMENT'] ) {
+		$upstream_updates_api_url .= '?base_branch=refs%2Fheads%2F'.$_ENV['PANTHEON_ENVIRONMENT'];
+	}
+
+	$data = _pantheon_curl_cached( $upstream_updates_api_url );
+	if ( empty( $data['update_log'] ) ) {
+		return false;
+	}
+	return true;
 }
 
 function _pantheon_curl_cached( $api_url ) {
@@ -44,9 +98,9 @@ function _pantheon_curl_cached( $api_url ) {
 function _pantheon_upstream_update_notice() {
 	$update_type = 'new WordPress version';
 	$update_help = 'If you need help, open a support chat on Pantheon.';
-	$data = _pantheon_curl_cached( 'https://api.live.getpantheon.com/sites/self/code-upstream-updates' );
-	if ( ! empty( $data['remote_url'] ) && false === stripos( $data['remote_url'], '/pantheon-systems/' ) ) {
-		$update_type = 'Pantheon Custom Upstream update';
+	$upstream_path = _pantheon_fetch_custom_upstream_info();
+	if ( ! empty( $upstream_path ) ) {
+		$update_type = 'Pantheon Custom Upstream update from "'.$upstream_path.'"';
 		$update_help = 'If you need help, contact an administrator for your Pantheon organization.';
 	}
 
@@ -64,7 +118,8 @@ function _pantheon_upstream_update_notice() {
 // Register Pantheon specific WordPress update admin notice
 add_action( 'admin_init', '_pantheon_register_upstream_update_notice' );
 function _pantheon_register_upstream_update_notice(){
-    // but only if we are on Pantheon and there is a WordPress update available
+	// but only if we are on Pantheon
+	// and there is a WordPress update available
 	if( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) && _pantheon_wordpress_update_available() ){
 		add_action( 'admin_notices', '_pantheon_upstream_update_notice' );
 	}
@@ -82,7 +137,7 @@ function _pantheon_disable_wp_updates() {
 
 // In the Test and Live environments, clear plugin/theme update notifications.
 // Users must check a dev or multidev environment for updates.
-if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], Array('test', 'live') ) && (php_sapi_name() !== 'cli') ) {
+if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array('test', 'live') ) && (php_sapi_name() !== 'cli') ) {
 
 	// Disable Plugin Updates
 	remove_action( 'load-update-core.php', 'wp_update_plugins' );


### PR DESCRIPTION
A fresh copy of @ataylorme's PR #217, as the original branch is stuck in limbo returning 404 & has merge conflict in .circleci/.

---
Partially addresses #216

- Do not show an update notice when using the default upstream and WordPress core is up to date
- Only show the upstream update notice on dev
  - https://api.live.getpantheon.com/sites/self/code-upstream-updates does not return multidev information, so displaying an accurate notice on those environments is not feasible.
- Only disable WordPress auto updates when on Pantheon