### PR TITLE
[OTTO-360] change default wp-config from utf8 to utf8mb4

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -38,7 +38,7 @@ else:
     define('DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT']);
 
     /** Database Charset to use in creating database tables. */
-    define('DB_CHARSET', 'utf8');
+    define('DB_CHARSET', 'utf8mb4');
 
     /** The Database Collate type. Don't change this if in doubt. */
     define('DB_COLLATE', '');


### PR DESCRIPTION
fixes #160 

Historical context: https://make.wordpress.org/core/2015/04/02/the-utf8mb4-upgrade/

WordPress core has been setting this as the default for new sites for 3+ years (assuming the DB supports the feature)
https://github.com/WordPress/WordPress/blame/26bda18a23174afb048afbe62296c76a62add542/wp-admin/setup-config.php#L377

this setting is supported by all the MariaDb versions that I can find.