### PR TITLE
Amended WordPress 5.4.2 release.

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -10,8 +10,8 @@ enforce_https: transitional
 
 # See https://pantheon.io/docs/pantheon-yml#protected-web-paths for usage.
 protected_web_paths:
-  - /private
-  - /wp-content/uploads/private
+  - /private/
+  - /wp-content/uploads/private/
   - /xmlrpc.php
 
 # By default, any 'protected_web_paths' added to the pantheon.yml file


### PR DESCRIPTION
The WordPress 5.4.2 release included an additional change to the way Pantheon manages protected web paths by adding the list explicitly to the pantheon.upstream.yml file. The paths listed in the new location were missing the trailing '/' character, which changed the behavior of the path matching. This amended release restores the missing trailing slashes. No changes to WordPress itself are included.