### PR TITLE
Remove duplicate *.log reference.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ wp-content/advanced-cache.php
 wp-content/wp-cache-config.php
 sitemap.xml
 sitemap.xml.gz
-*.log
 
 # @TODO writable paths
 wp-content/cache/


### PR DESCRIPTION
Duplicate of https://github.com/pantheon-systems/WordPress/pull/219, rebased to resolve .circleci conflict.