### PR TITLE
Add a composer.json file to enable use with Composer 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,37 @@
+{
+	"name": "pantheon-systems/wordpress",
+	"description": "WordPress upstream for the Pantheon website platform. Includes a platform integration plugins and a pre-configured wp-config.php.",
+	"license": "GPL-2.0-or-later",
+	"type": "wordpress-core",
+	"keywords": [
+		"wordpress",
+		"cms",
+		"webops",
+		"managed"
+	],
+	"homepage": "https://pantheon.io/",
+	"authors": [
+		{
+			"name": "WordPress Community",
+			"homepage": "https://wordpress.org/about/"
+		},
+		{
+			"name": "Pantheon",
+			"homepage": "https://pantheon.io/company/"
+		}
+	],
+	"support": {
+		"chat": "https://pantheon.io/docs/support#real-time-chat-support",
+		"docs": "https://pantheon.io/docs/develop/",
+		"forum": "https://pantheon-community.slack.com/#/",
+		"issues": "https://github.com/pantheon-systems/WordPress/issues",
+		"source": "https://github.com/pantheon-systems/WordPress"
+	},
+	"require": {
+		"php": ">=5.6.20",
+		"ext-json": "*"
+	},
+	"provide": {
+		"wordpress/core-implementation": "dev-master"
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 			"homepage": "https://wordpress.org/about/"
 		},
 		{
-			"name": "Pantheon",
+			"name": "Pantheon Systems",
 			"homepage": "https://pantheon.io/company/"
 		}
 	],


### PR DESCRIPTION
Per a discussion with Oliver Seldman he suggested using the Pantheon Upstream as our WordPress dependency instead of using [johnpbloch/wordpress-core](https://github.com/johnpbloch/wordpress-core) which is what we had been using.

Unfortunately your upstream does not contain a `composer.json` file so we cannot use it in that manner.

This PR adds the `composer.json` file that is needed to support using your upstream with Composer.

For more information about composer see [getcomposer.org](https://getcomposer.org) and [_Using Composer With WordPress_](https://www.smashingmagazine.com/2019/03/composer-wordpress/).