### PR TITLE
[OTTO-395] set WP_ENVIRONMENT_TYPE according to Pantheon environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ wp-content/advanced-cache.php
 wp-content/wp-cache-config.php
 sitemap.xml
 sitemap.xml.gz
-*.log
 
 # @TODO writable paths
 wp-content/cache/

--- a/wp-config-pantheon.php
+++ b/wp-config-pantheon.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Pantheon platform settings.
+ *
+ * IMPORTANT NOTE:
+ * Do not modify this file. This file is maintained by Pantheon.
+ *
+ * Site-specific modifications belong in wp-config.php, not this file. This
+ * file may change in future releases and modifications would cause conflicts
+ * when attempting to apply upstream updates.
+ */
+
+// ** MySQL settings - included in the Pantheon Environment ** //
+/** The name of the database for WordPress */
+define('DB_NAME', $_ENV['DB_NAME']);
+
+/** MySQL database username */
+define('DB_USER', $_ENV['DB_USER']);
+
+/** MySQL database password */
+define('DB_PASSWORD', $_ENV['DB_PASSWORD']);
+
+/** MySQL hostname; on Pantheon this includes a specific port number. */
+define('DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT']);
+
+/** Database Charset to use in creating database tables. */
+define('DB_CHARSET', 'utf8mb4');
+
+/** The Database Collate type. Don't change this if in doubt. */
+define('DB_COLLATE', '');
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
+ *
+ * Pantheon sets these values for you also. If you want to shuffle them you
+ * must contact support: https://pantheon.io/docs/getting-support
+ *
+ * @since 2.6.0
+ */
+define('AUTH_KEY', $_ENV['AUTH_KEY']);
+define('SECURE_AUTH_KEY', $_ENV['SECURE_AUTH_KEY']);
+define('LOGGED_IN_KEY', $_ENV['LOGGED_IN_KEY']);
+define('NONCE_KEY', $_ENV['NONCE_KEY']);
+define('AUTH_SALT', $_ENV['AUTH_SALT']);
+define('SECURE_AUTH_SALT', $_ENV['SECURE_AUTH_SALT']);
+define('LOGGED_IN_SALT', $_ENV['LOGGED_IN_SALT']);
+define('NONCE_SALT', $_ENV['NONCE_SALT']);
+/**#@-*/
+
+/** A couple extra tweaks to help things run well on Pantheon. **/
+if (isset($_SERVER['HTTP_HOST'])) {
+    // HTTP is still the default scheme for now.
+    $scheme = 'http';
+    // If we have detected that the end use is HTTPS, make sure we pass that
+    // through here, so <img> tags and the like don't generate mixed-mode
+    // content warnings.
+    if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON') {
+        $scheme = 'https';
+        $_SERVER['HTTPS'] = 'on';
+    }
+    define('WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST']);
+    define('WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST']);
+}
+// Don't show deprecations; useful under PHP 5.5
+error_reporting(E_ALL ^ E_DEPRECATED);
+/** Define appropriate location for default tmp directory on Pantheon */
+define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp');
+
+// FS writes aren't permitted in test or live, so we should let WordPress know to disable relevant UI
+if (in_array($_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' )) && ! defined('DISALLOW_FILE_MODS')) {
+    define('DISALLOW_FILE_MODS', true);
+}
+
+/**
+ * Set WP_ENVIRONMENT_TYPE according to the Pantheon Environment
+ */
+if (getenv('WP_ENVIRONMENT_TYPE') === false) {
+    switch ($_ENV['PANTHEON_ENVIRONMENT']) {
+        case 'live':
+            putenv('WP_ENVIRONMENT_TYPE=production');
+            break;
+        case 'test':
+            putenv('WP_ENVIRONMENT_TYPE=staging');
+            break;
+        default:
+            putenv('WP_ENVIRONMENT_TYPE=development');
+            break;
+    }
+}

--- a/wp-config.php
+++ b/wp-config.php
@@ -24,71 +24,9 @@ if (file_exists(dirname(__FILE__) . '/wp-config-local.php') && !isset($_ENV['PAN
  */
 else:
   if (isset($_ENV['PANTHEON_ENVIRONMENT'])):
-    // ** MySQL settings - included in the Pantheon Environment ** //
-    /** The name of the database for WordPress */
-    define('DB_NAME', $_ENV['DB_NAME']);
-
-    /** MySQL database username */
-    define('DB_USER', $_ENV['DB_USER']);
-
-    /** MySQL database password */
-    define('DB_PASSWORD', $_ENV['DB_PASSWORD']);
-
-    /** MySQL hostname; on Pantheon this includes a specific port number. */
-    define('DB_HOST', $_ENV['DB_HOST'] . ':' . $_ENV['DB_PORT']);
-
-    /** Database Charset to use in creating database tables. */
-    define('DB_CHARSET', 'utf8mb4');
-
-    /** The Database Collate type. Don't change this if in doubt. */
-    define('DB_COLLATE', '');
-
-    /**#@+
-     * Authentication Unique Keys and Salts.
-     *
-     * Change these to different unique phrases!
-     * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
-     * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
-     *
-     * Pantheon sets these values for you also. If you want to shuffle them you
-     * must contact support: https://pantheon.io/docs/getting-support 
-     *
-     * @since 2.6.0
-     */
-    define('AUTH_KEY',         $_ENV['AUTH_KEY']);
-    define('SECURE_AUTH_KEY',  $_ENV['SECURE_AUTH_KEY']);
-    define('LOGGED_IN_KEY',    $_ENV['LOGGED_IN_KEY']);
-    define('NONCE_KEY',        $_ENV['NONCE_KEY']);
-    define('AUTH_SALT',        $_ENV['AUTH_SALT']);
-    define('SECURE_AUTH_SALT', $_ENV['SECURE_AUTH_SALT']);
-    define('LOGGED_IN_SALT',   $_ENV['LOGGED_IN_SALT']);
-    define('NONCE_SALT',       $_ENV['NONCE_SALT']);
-    /**#@-*/
-
-    /** A couple extra tweaks to help things run well on Pantheon. **/
-    if (isset($_SERVER['HTTP_HOST'])) {
-        // HTTP is still the default scheme for now. 
-        $scheme = 'http';
-        // If we have detected that the end use is HTTPS, make sure we pass that
-        // through here, so <img> tags and the like don't generate mixed-mode
-        // content warnings.
-        if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] == 'ON') {
-            $scheme = 'https';
-            $_SERVER['HTTPS'] = 'on';
-        }
-        define('WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST']);
-        define('WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST']);
-    }
-    // Don't show deprecations; useful under PHP 5.5
-    error_reporting(E_ALL ^ E_DEPRECATED);
-    /** Define appropriate location for default tmp directory on Pantheon */
-    define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp');
-
-    // FS writes aren't permitted in test or live, so we should let WordPress know to disable relevant UI
-    if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array( 'test', 'live' ) ) && ! defined( 'DISALLOW_FILE_MODS' ) ) :
-        define( 'DISALLOW_FILE_MODS', true );
+    if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php')) :
+      require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
     endif;
-
   else:
     /**
      * This block will be executed if you have NO wp-config-local.php and you


### PR DESCRIPTION
WordPress 5.5 introduces `wp_get_environment_type()`, which returns a site's environment type as defined by the constant `WP_ENVIRONMENT_TYPE`. 

The `live` environment returns `production`, `test` returns `staging`, and all other environments (`dev`, all multidevs) return `development`.


References:
https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/