### PR TITLE
[OTTO-406] wp-config.php: removed deprecated WPLANG, refactored "if" logic/syntax

### DIFF
--- a/wp-config-pantheon.php
+++ b/wp-config-pantheon.php
@@ -32,12 +32,9 @@ define('DB_COLLATE', '');
 /**#@+
  * Authentication Unique Keys and Salts.
  *
- * Change these to different unique phrases!
- * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
- * You can change these at any point in time to invalidate all existing cookies. This will force all users to have to log in again.
- *
- * Pantheon sets these values for you also. If you want to shuffle them you
- * must contact support: https://pantheon.io/docs/getting-support
+ * Changing these will force all users to have to log in again.
+ * Pantheon sets these values for you. If you want to shuffle them you must
+ * contact support: https://pantheon.io/docs/getting-support
  *
  * @since 2.6.0
  */

--- a/wp-config.php
+++ b/wp-config.php
@@ -9,47 +9,45 @@
  */
 
 /**
+ * Pantheon platform settings. Everything you need should already be set.
+ */
+if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+	require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
+
+/**
  * Local configuration information.
  *
  * If you are working in a local/desktop development environment and want to
  * keep your config separate, we recommend using a 'wp-config-local.php' file,
  * which you should also make sure you .gitignore.
  */
-if (file_exists(dirname(__FILE__) . '/wp-config-local.php') && !isset($_ENV['PANTHEON_ENVIRONMENT'])):
-  # IMPORTANT: ensure your local config does not include wp-settings.php
-  require_once(dirname(__FILE__) . '/wp-config-local.php');
+} elseif (file_exists(dirname(__FILE__) . '/wp-config-local.php') && !isset($_ENV['PANTHEON_ENVIRONMENT'])){
+	# IMPORTANT: ensure your local config does not include wp-settings.php
+	require_once(dirname(__FILE__) . '/wp-config-local.php');
 
 /**
- * Pantheon platform settings. Everything you need should already be set.
+ * This block will be executed if you are NOT running on Pantheon and have NO
+ * wp-config-local.php. Insert alternate config here if necessary.
+ *
+ * If you are only running on Pantheon, you can ignore this block.
  */
-else:
-  if (isset($_ENV['PANTHEON_ENVIRONMENT'])):
-    if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php')) :
-      require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
-    endif;
-  else:
-    /**
-     * This block will be executed if you have NO wp-config-local.php and you
-     * are NOT running on Pantheon. Insert alternate config here if necessary.
-     *
-     * If you are only running on Pantheon, you can ignore this block.
-     */
-    define('DB_NAME',          'database_name');
-    define('DB_USER',          'database_username');
-    define('DB_PASSWORD',      'database_password');
-    define('DB_HOST',          'database_host');
-    define('DB_CHARSET',       'utf8');
-    define('DB_COLLATE',       '');
-    define('AUTH_KEY',         'put your unique phrase here');
-    define('SECURE_AUTH_KEY',  'put your unique phrase here');
-    define('LOGGED_IN_KEY',    'put your unique phrase here');
-    define('NONCE_KEY',        'put your unique phrase here');
-    define('AUTH_SALT',        'put your unique phrase here');
-    define('SECURE_AUTH_SALT', 'put your unique phrase here');
-    define('LOGGED_IN_SALT',   'put your unique phrase here');
-    define('NONCE_SALT',       'put your unique phrase here');
-  endif;
-endif;
+} else {
+	define('DB_NAME',          'database_name');
+	define('DB_USER',          'database_username');
+	define('DB_PASSWORD',      'database_password');
+	define('DB_HOST',          'database_host');
+	define('DB_CHARSET',       'utf8');
+	define('DB_COLLATE',       '');
+	define('AUTH_KEY',         'put your unique phrase here');
+	define('SECURE_AUTH_KEY',  'put your unique phrase here');
+	define('LOGGED_IN_KEY',    'put your unique phrase here');
+	define('NONCE_KEY',        'put your unique phrase here');
+	define('AUTH_SALT',        'put your unique phrase here');
+	define('SECURE_AUTH_SALT', 'put your unique phrase here');
+	define('LOGGED_IN_SALT',   'put your unique phrase here');
+	define('NONCE_SALT',       'put your unique phrase here');
+}
+
 
 /** Standard wp-config.php stuff from here on down. **/
 
@@ -62,16 +60,6 @@ endif;
 $table_prefix = 'wp_';
 
 /**
- * WordPress Localized Language, defaults to English.
- *
- * Change this to localize WordPress. A corresponding MO file for the chosen
- * language must be installed to wp-content/languages. For example, install
- * de_DE.mo to wp-content/languages and set WPLANG to 'de_DE' to enable German
- * language support.
- */
-define('WPLANG', '');
-
-/**
  * For developers: WordPress debugging mode.
  *
  * Change this to true to enable the display of notices during development.
@@ -82,7 +70,7 @@ define('WPLANG', '');
  * "true" in dev, but false in test and live.
  */
 if ( ! defined( 'WP_DEBUG' ) ) {
-    define('WP_DEBUG', false);
+	define('WP_DEBUG', false);
 }
 
 /* That's all, stop editing! Happy Pressing. */


### PR DESCRIPTION
Per https://core.trac.wordpress.org/changeset/29630

This constant was deprecated in WordPress some time ago and should be removed from wp-config altogether since it is no longer used. The database instead provides this option.

Also clarifies language around keys & salts in `wp-config-pantheon.php`

Closes #83
Closes #252