### PR TITLE
Refactor the logic that includes wp-config-pantheon.php

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -9,46 +9,43 @@
  */
 
 /**
+ * Pantheon platform settings. Everything you need should already be set.
+ */
+if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php') && isset($_ENV['PANTHEON_ENVIRONMENT'])):
+  require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
+
+/**
  * Local configuration information.
  *
  * If you are working in a local/desktop development environment and want to
  * keep your config separate, we recommend using a 'wp-config-local.php' file,
  * which you should also make sure you .gitignore.
  */
-if (file_exists(dirname(__FILE__) . '/wp-config-local.php') && !isset($_ENV['PANTHEON_ENVIRONMENT'])):
+elseif (file_exists(dirname(__FILE__) . '/wp-config-local.php') && !isset($_ENV['PANTHEON_ENVIRONMENT'])):
   # IMPORTANT: ensure your local config does not include wp-settings.php
   require_once(dirname(__FILE__) . '/wp-config-local.php');
 
 /**
- * Pantheon platform settings. Everything you need should already be set.
+ * This block will be executed if you have NO wp-config-local.php and you
+ * are NOT running on Pantheon. Insert alternate config here if necessary.
+ *
+ * If you are only running on Pantheon, you can ignore this block.
  */
 else:
-  if (isset($_ENV['PANTHEON_ENVIRONMENT'])):
-    if (file_exists(dirname(__FILE__) . '/wp-config-pantheon.php')) :
-      require_once(dirname(__FILE__) . '/wp-config-pantheon.php');
-    endif;
-  else:
-    /**
-     * This block will be executed if you have NO wp-config-local.php and you
-     * are NOT running on Pantheon. Insert alternate config here if necessary.
-     *
-     * If you are only running on Pantheon, you can ignore this block.
-     */
-    define('DB_NAME',          'database_name');
-    define('DB_USER',          'database_username');
-    define('DB_PASSWORD',      'database_password');
-    define('DB_HOST',          'database_host');
-    define('DB_CHARSET',       'utf8');
-    define('DB_COLLATE',       '');
-    define('AUTH_KEY',         'put your unique phrase here');
-    define('SECURE_AUTH_KEY',  'put your unique phrase here');
-    define('LOGGED_IN_KEY',    'put your unique phrase here');
-    define('NONCE_KEY',        'put your unique phrase here');
-    define('AUTH_SALT',        'put your unique phrase here');
-    define('SECURE_AUTH_SALT', 'put your unique phrase here');
-    define('LOGGED_IN_SALT',   'put your unique phrase here');
-    define('NONCE_SALT',       'put your unique phrase here');
-  endif;
+  define('DB_NAME',          'database_name');
+  define('DB_USER',          'database_username');
+  define('DB_PASSWORD',      'database_password');
+  define('DB_HOST',          'database_host');
+  define('DB_CHARSET',       'utf8');
+  define('DB_COLLATE',       '');
+  define('AUTH_KEY',         'put your unique phrase here');
+  define('SECURE_AUTH_KEY',  'put your unique phrase here');
+  define('LOGGED_IN_KEY',    'put your unique phrase here');
+  define('NONCE_KEY',        'put your unique phrase here');
+  define('AUTH_SALT',        'put your unique phrase here');
+  define('SECURE_AUTH_SALT', 'put your unique phrase here');
+  define('LOGGED_IN_SALT',   'put your unique phrase here');
+  define('NONCE_SALT',       'put your unique phrase here');
 endif;
 
 /** Standard wp-config.php stuff from here on down. **/


### PR DESCRIPTION
In PR #250 and subsequent merge commit 0331b3286e4807682ff682f29c84188c213bb92c there is the introduction of a `require_once` for the file `wp-config-pantheon.php`.

This PR refactors this logic to follow the pattern set for the `if` `file_exists` statement used for the `wp-config-local.php` and reduces the logic statements for this section to one level deep. This protects against a situation where WordPress would fail to run because the `PANTHEON_ENVIRONMENT` is set but for some reason the `wp-config-pantheon.php` file does not exist.