### PR TITLE
Update to WordPress 5.5.3. For more information, see https://wordpress.org/news/2020/10/wordpress-5-5-3-maintenance-release/

### DIFF
--- a/wp-admin/about.php
+++ b/wp-admin/about.php
@@ -67,6 +67,31 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<p>
 					<?php
 					printf(
+						/* translators: 1: WordPress version number, 2: Plural number of bugs. */
+						_n(
+							'<strong>Version %1$s</strong> addressed %2$s bug.',
+							'<strong>Version %1$s</strong> addressed %2$s bugs.',
+							1
+						),
+						'5.5.3',
+						number_format_i18n( 1 )
+					);
+					?>
+					<?php
+					printf(
+						/* translators: %s: HelpHub URL. */
+						__( 'For more information, see <a href="%s">the release notes</a>.' ),
+						sprintf(
+							/* translators: %s: WordPress version. */
+							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+							sanitize_title( '5.5.3' )
+						)
+					);
+					?>
+				</p>
+				<p>
+					<?php
+					printf(
 						/* translators: 1: WordPress version number, 2: plural number of bugs. More than one security issue. */
 						_n(
 							'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug.',

--- a/wp-includes/functions.php
+++ b/wp-includes/functions.php
@@ -1754,7 +1754,10 @@ function is_blog_installed() {
 		}
 
 		$described_table = $wpdb->get_results( "DESCRIBE $table;" );
-		if ( is_array( $described_table ) && count( $described_table ) === 0 ) {
+		if (
+			( ! $described_table && empty( $wpdb->last_error ) ) ||
+			( is_array( $described_table ) && 0 === count( $described_table ) )
+		) {
 			continue;
 		}
 

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -13,7 +13,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '5.5.2';
+$wp_version = '5.5.3';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
Update from WordPress 5.5.2 to WordPress 5.5.3.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/WordPress), and then visit the test site and confirm that the correct version of WordPress was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new WordPress site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add wp git@github.com:pantheon-systems/WordPress.git
    - git fetch wp
    - git merge wp/update-5.5.3
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
