### PR TITLE
Update to WordPress 5.7.2. For more information, see https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/

### DIFF
--- a/wp-admin/about.php
+++ b/wp-admin/about.php
@@ -72,6 +72,27 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<p>
 					<?php
 					printf(
+						/* translators: %s: WordPress version number. */
+						__( '<strong>Version %s</strong> addressed one security issue.' ),
+						'5.7.2'
+					);
+					?>
+					<?php
+					printf(
+						/* translators: %s: HelpHub URL. */
+						__( 'For more information, see <a href="%s">the release notes</a>.' ),
+						sprintf(
+							/* translators: %s: WordPress version. */
+							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+							sanitize_title( '5.7.2' )
+						)
+					);
+					?>
+				</p>
+
+				<p>
+					<?php
+					printf(
 						/* translators: 1: WordPress version number, 2: Plural number of bugs. More than one security issue. */
 						_n(
 							'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug.',

--- a/wp-includes/PHPMailer/PHPMailer.php
+++ b/wp-includes/PHPMailer/PHPMailer.php
@@ -748,7 +748,7 @@ class PHPMailer
      *
      * @var string
      */
-    const VERSION = '6.4.0';
+    const VERSION = '6.4.1';
 
     /**
      * Error severity: message only, continue processing.
@@ -1723,9 +1723,10 @@ class PHPMailer
                 fwrite($mail, $header);
                 fwrite($mail, $body);
                 $result = pclose($mail);
+                $addrinfo = static::parseAddresses($toAddr);
                 $this->doCallback(
                     ($result === 0),
-                    [$toAddr],
+                    [[$addrinfo['address'], $addrinfo['name']]],
                     $this->cc,
                     $this->bcc,
                     $this->Subject,
@@ -1812,7 +1813,8 @@ class PHPMailer
      */
     protected static function isPermittedPath($path)
     {
-        return !preg_match('#^[a-z]+://#i', $path);
+        //Matches scheme definition from https://tools.ietf.org/html/rfc3986#section-3.1
+        return !preg_match('#^[a-z][a-z\d+.-]*://#i', $path);
     }
 
     /**
@@ -1824,12 +1826,15 @@ class PHPMailer
      */
     protected static function fileIsAccessible($path)
     {
+        if (!static::isPermittedPath($path)) {
+            return false;
+        }
         $readable = file_exists($path);
         //If not a UNC path (expected to start with \\), check read permission, see #2069
         if (strpos($path, '\\\\') !== 0) {
             $readable = $readable && is_readable($path);
         }
-        return static::isPermittedPath($path) && $readable;
+        return  $readable;
     }
 
     /**
@@ -1878,7 +1883,17 @@ class PHPMailer
         if ($this->SingleTo && count($toArr) > 1) {
             foreach ($toArr as $toAddr) {
                 $result = $this->mailPassthru($toAddr, $this->Subject, $body, $header, $params);
-                $this->doCallback($result, [$toAddr], $this->cc, $this->bcc, $this->Subject, $body, $this->From, []);
+                $addrinfo = static::parseAddresses($toAddr);
+                $this->doCallback(
+                    $result,
+                    [[$addrinfo['address'], $addrinfo['name']]],
+                    $this->cc,
+                    $this->bcc,
+                    $this->Subject,
+                    $body,
+                    $this->From,
+                    []
+                );
             }
         } else {
             $result = $this->mailPassthru($to, $this->Subject, $body, $header, $params);
@@ -1967,7 +1982,7 @@ class PHPMailer
                     $isSent = true;
                 }
 
-                $callbacks[] = ['issent' => $isSent, 'to' => $to[0]];
+                $callbacks[] = ['issent' => $isSent, 'to' => $to[0], 'name' => $to[1]];
             }
         }
 
@@ -1988,7 +2003,7 @@ class PHPMailer
         foreach ($callbacks as $cb) {
             $this->doCallback(
                 $cb['issent'],
-                [$cb['to']],
+                [[$cb['to'], $cb['name']]],
                 [],
                 [],
                 $this->Subject,

--- a/wp-includes/PHPMailer/SMTP.php
+++ b/wp-includes/PHPMailer/SMTP.php
@@ -35,7 +35,7 @@ class SMTP
      *
      * @var string
      */
-    const VERSION = '6.4.0';
+    const VERSION = '6.4.1';
 
     /**
      * SMTP line break constant.

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -13,7 +13,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '5.7.1';
+$wp_version = '5.7.2';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
Update from WordPress 5.7.1 to WordPress 5.7.2.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/WordPress), and then visit the test site and confirm that the correct version of WordPress was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new WordPress site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add wp git@github.com:pantheon-systems/WordPress.git
    - git fetch wp
    - git merge wp/update-5.7.2
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
