### PR TITLE
Trigger CircleCI for PR #287

### DIFF
--- a/wp-content/mu-plugins/pantheon/pantheon-updates.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-updates.php
@@ -105,7 +105,7 @@ function _pantheon_upstream_update_notice() {
 	}
 
     ?>
-    <div class="update-nag">
+    <div class="update-nag notice notice-warning">
 		<p style="font-size: 14px; font-weight: bold; margin: 0 0 0.5em 0;">
 			A <?php echo $update_type; ?> is available! Please update from <a href="https://dashboard.pantheon.io/sites/<?php echo $_ENV['PANTHEON_SITE']; ?>">your Pantheon dashboard</a>.
 		</p>


### PR DESCRIPTION
As noted in https://github.com/pantheon-systems/WordPress/issues/274, some of the .update-nag formatting went missing a while back, which makes the nag formatting appear somewhat inconsistent with other WordPress notices.

This commit restores the formatting that makes the nag look like other warning notices, using standard WordPress CSS class names.