### PR TITLE
Use PHP 7.4 by default for new WordPress sites.

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,7 +3,7 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 7.3
+php_version: 7.4
 
 # See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
 enforce_https: transitional


### PR DESCRIPTION
PHP 7.4 is the current recommendation from WP: https://wordpress.org/about/requirements/