### PR TITLE
[CMS-144] Show a more meaningful notice when trying to install WP plugin in Git mode

### DIFF
--- a/wp-content/mu-plugins/pantheon.php
+++ b/wp-content/mu-plugins/pantheon.php
@@ -19,6 +19,9 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	if ( ! defined('RETURN_TO_PANTHEON_BUTTON') || RETURN_TO_PANTHEON_BUTTON ) {
 		require_once 'pantheon/pantheon-login-form-mods.php';
 	}
+	if ( 'dev' === $_ENV['PANTHEON_ENVIRONMENT'] && function_exists( 'wp_is_writable' ) ) {
+		require_once 'pantheon/pantheon-plugin-install-notice.php';
+	}
 	if ( ! defined( 'FS_METHOD' ) ) {
 		/**
 		 * When this constant is not set, WordPress writes and then deletes a 

--- a/wp-content/mu-plugins/pantheon/pantheon-plugin-install-notice.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-plugin-install-notice.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * If a Pantheon site is in Git mode, hide the Plugin installation functionality and show a notice.
+ */
+
+if ( ! wp_is_writable( WP_PLUGIN_DIR ) ) {
+    if ( ! defined( 'DISALLOW_FILE_MODS' ) ) {
+        define( 'DISALLOW_FILE_MODS', true );
+    }
+
+    add_action( 'admin_notices', '_pantheon_plugin_install_notice' );
+    add_action( 'network_admin_notices', '_pantheon_plugin_install_notice' );
+}
+
+function _pantheon_plugin_install_notice() {
+    $screen = get_current_screen(); 
+    // Only show this notice on the plugins page.
+    if ( 'plugins' === $screen->id || 'plugins-network' === $screen->id ) { ?>
+        <div class="update-nag notice notice-warning is-dismissible" style="margin: 5px 6em 15px 0;">
+            <p style="font-size: 14px; margin: 0;">
+                <?php 
+                // Translators: %s is a URL to the user's Pantheon Dashboard.
+                echo wp_kses_post( sprintf( __( 'If you wish to update or add plugins using the WordPress UI, switch your site to SFTP mode from <a href="%s">your Pantheon dashboard</a>.', 'pantheon-systems' ), 'https://dashboard.pantheon.io/sites/' . $_ENV['PANTHEON_SITE'] ) ); 
+                ?>
+            </p>
+        </div>
+        <?php
+    }
+}


### PR DESCRIPTION
The current error message when trying to update or add a plugin using the WP admin when a site is in Git mode is not very intuitive:

<img width="585" alt="Screen Shot 2022-05-17 at 8 55 09 AM" src="https://user-images.githubusercontent.com/17913282/168843051-6ac7aa88-b434-4e7e-a767-23f58aa516ba.png">

<img width="596" alt="Screen Shot 2022-05-17 at 8 54 53 AM" src="https://user-images.githubusercontent.com/17913282/168843083-1c4deefb-7abd-4ab5-bc3c-f16e984bfd82.png">

This PR detects if a site is in Git mode and, if so, disables plugin installation UI and adds a notice to _only_ the plugins page:

<img width="883" alt="Screen Shot 2022-05-17 at 9 15 27 AM" src="https://user-images.githubusercontent.com/17913282/168846574-77514fdb-44e0-439d-b1b7-ea9ab7334774.png">

If the site is in SFTP mode, the installation UI is present nothing is shown:

<img width="457" alt="Screen Shot 2022-05-17 at 9 02 09 AM" src="https://user-images.githubusercontent.com/17913282/168843707-baf2e72e-f98c-40e7-879a-a6fb02de44c1.png">