### PR TITLE
[CMS-799] Deprecates pantheon-cache in favor of pantheon cache

### DIFF
--- a/wp-content/mu-plugins/pantheon.php
+++ b/wp-content/mu-plugins/pantheon.php
@@ -3,7 +3,7 @@
  * Plugin Name: Pantheon
  * Plugin URI: https://pantheon.io/
  * Description: Building on Pantheon's and WordPress's strengths, together.
- * Version: 0.2
+ * Version: 0.3
  * Author: Pantheon
  * Author URI: https://pantheon.io/
  *
@@ -22,14 +22,17 @@ if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 	if ( 'dev' === $_ENV['PANTHEON_ENVIRONMENT'] && function_exists( 'wp_is_writable' ) ) {
 		require_once 'pantheon/pantheon-plugin-install-notice.php';
 	}
+    if ( defined( 'WP_CLI' ) && WP_CLI ) {
+        require_once 'pantheon/cli.php';
+    }
 	if ( ! defined( 'FS_METHOD' ) ) {
 		/**
-		 * When this constant is not set, WordPress writes and then deletes a 
+		 * When this constant is not set, WordPress writes and then deletes a
 		 * temporary file to determine if it has direct access to the filesystem,
-		 * which we already know to be the case.  This multiplies filesystem 
+		 * which we already know to be the case.  This multiplies filesystem
 		 * operations and can degrade performance of the filesystem as a whole in
-		 * the case of large sites that do a lot of filesystem operations.  
-		 * Setting this constant to 'direct' tells WordPress to assume it has 
+		 * the case of large sites that do a lot of filesystem operations.
+		 * Setting this constant to 'direct' tells WordPress to assume it has
 		 * direct access and skip creating the extra temporary file.
 		 */
 		define( 'FS_METHOD', 'direct' );

--- a/wp-content/mu-plugins/pantheon/cli.php
+++ b/wp-content/mu-plugins/pantheon/cli.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * WP-CLI commands for the Pantheon mu-plugin.
+ *
+ * @package pantheon
+ */
+
+namespace Pantheon\CLI;
+
+use Pantheon_Cache;
+use WP_CLI;
+
+// Support the old pantheon-cache command but return a deprecation notice.
+WP_CLI::add_command( 'pantheon-cache set-maintenance-mode', '\\Pantheon\\CLI\\__deprecated_maintenance_mode_output' );
+WP_CLI::add_command( 'pantheon cache set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
+WP_CLI::add_command( 'pantheon set-maintenance-mode', '\\Pantheon\\CLI\\set_maintenance_mode_command' );
+
+/**
+ * Sets maintenance mode status.
+ *
+ * Enable maintenance mode to work on your site while serving cached pages
+ * to visitors and bots, or everyone except administators.
+ *
+ * ## DEPRECATION NOTICE
+ *
+ * This command is deprecated and will be removed in a future release.
+ * Use `pantheon set-maintenance-mode` instead.
+ *
+ * ## USAGE
+ *
+ * wp pantheon-cache set-maintenance-mode <status> (deprecated) or
+ * wp pantheon cache set-maintenance-mode <status>
+ *
+ * ## OPTIONS
+ *
+ * <status>
+ * : Maintenance mode status.
+ * ---
+ * options:
+ *   - disabled
+ *   - anonymous
+ *   - everyone
+ * ---
+ *
+ * @subcommand set-maintenance-mode
+ *
+ * @deprecated 1.0.0
+ */
+function __deprecated_maintenance_mode_output( $args ) {
+	$allowed_args = [ 'disabled', 'anonymous', 'everyone' ];
+	$replacement_command = ( ! empty( $args  && count( $args ) === 1 ) && in_array( $args[0], $allowed_args, true ) ) ? 'set-maintenance-mode ' . $args[0] : false;
+
+	WP_CLI::warning( WP_CLI::colorize( '%y' . sprintf( __( 'This command is deprecated and will be removed in a future release. Use `wp pantheon %s` instead.', 'pantheon-systems' ), $replacement_command ) . '%n' ) );
+	WP_CLI::line( __( 'Run `wp pantheon set-maintenance-mode --help` for more information.', 'pantheon-systems' ) );
+
+	// The command should fail before we get here, but in case it doesn't, display an error.
+	if ( false === $replacement_command ) {
+		WP_CLI::error( __( 'Invalid arguments. Run `wp pantheon set-maintenance-mode --help` for more infomation.', 'pantheon-systems' ) );
+	}
+
+	set_maintenance_mode_command( $args );
+}
+
+/**
+ * Sets maintenance mode status.
+ *
+ * Enable maintenance mode to work on your site while serving cached pages
+ * to visitors and bots, or everyone except administators.
+ *
+ * ## OPTIONS
+ *
+ * <status>
+ * : Maintenance mode status.
+ * ---
+ * options:
+ *   - disabled
+ *   - anonymous
+ *   - everyone
+ * ---
+ *
+ * @subcommand set-maintenance-mode
+ */
+function set_maintenance_mode_command( $args ) {
+
+	list( $status ) = $args;
+
+	$out = Pantheon_Cache()->default_options;
+	if ( ! empty( $status )
+		&& in_array( $status, [ 'anonymous', 'everyone' ], true ) ) {
+		$out['maintenance_mode'] = $status;
+	} else {
+		$out['maintenance_mode'] = 'disabled';
+	}
+	update_option( Pantheon_Cache::SLUG, $out );
+	WP_CLI::success( sprintf( 'Maintenance mode set to: %s', $out['maintenance_mode'] ) );
+}

--- a/wp-content/mu-plugins/pantheon/pantheon-page-cache.php
+++ b/wp-content/mu-plugins/pantheon/pantheon-page-cache.php
@@ -498,40 +498,6 @@ class Pantheon_Cache {
 			pantheon_clear_edge_paths( $this->paths );
 		}
 	}
-
-	/**
-	 * Sets maintenance mode status.
-	 *
-	 * Enable maintenance mode to work on your site while serving cached pages
-	 * to visitors and bots, or everyone except administators.
-	 *
-	 * ## OPTIONS
-	 *
-	 * <status>
-	 * : Maintenance mode status.
-	 * ---
-	 * options:
-	 *   - disabled
-	 *   - anonymous
-	 *   - everyone
-	 * ---
-	 *
-	 * @subcommand set-maintenance-mode
-	 */
-	public function set_maintenance_mode_command( $args ) {
-
-		list( $status ) = $args;
-
-		$out = $this->default_options;
-		if ( ! empty( $status )
-			&& in_array( $status, [ 'anonymous', 'everyone' ], true ) ) {
-			$out['maintenance_mode'] = $status;
-		} else {
-			$out['maintenance_mode'] = 'disabled';
-		}
-		update_option( self::SLUG, $out );
-		WP_CLI::success( sprintf( 'Maintenance mode set to: %s', $out['maintenance_mode'] ) );
-	}
 }
 
 
@@ -547,11 +513,6 @@ function Pantheon_Cache() {
 	return Pantheon_Cache::instance();
 }
 add_action( 'plugins_loaded', 'Pantheon_Cache' );
-
-
-if ( defined( 'WP_CLI' ) && WP_CLI ) {
-	WP_CLI::add_command( 'pantheon-cache set-maintenance-mode', [ Pantheon_Cache::instance(), 'set_maintenance_mode_command' ] );
-}
 
 /**
  * @see Pantheon_Cache::clean_post_cache


### PR DESCRIPTION
Ports changes in pantheon-systems/pantheon-mu-plugin#2 to deprecate `wp pantheon-cache` in favor of using `wp pantheon cache`.

See pantheon-systems/pantheon-mu-plugin#2 for notes and full commit history