### PR TITLE
[BUGS-5709] fix undefined $hm_mu_plugins variable

### DIFF
--- a/wp-content/mu-plugins/loader.php
+++ b/wp-content/mu-plugins/loader.php
@@ -67,7 +67,7 @@ add_action( 'pre_current_active_plugins', function () use ( $pantheon_mu_plugins
 });
 
 add_filter( 'network_admin_plugin_action_links', function ( $actions, $plugin_file, $plugin_data, $context ) use ( $pantheon_mu_plugins ) {
-	if ( $context !== 'mustuse' || ! in_array( $plugin_file, $hm_mu_plugins, true ) ) {
+	if ( $context !== 'mustuse' || ! in_array( $plugin_file, $pantheon_mu_plugins, true ) ) {
 		return $actions;
 	}
 


### PR DESCRIPTION
There was one lingering trace of the $hm_mu_plugins variable that needed
to be replaced. This was causing a fatal error in PHP 8+.