### PR TITLE
Update to WordPress 6.2.2. For more information, see https://wordpress.org/news/2023/05/wordpress-6-2-2-security-release/

### DIFF
--- a/wp-admin/about.php
+++ b/wp-admin/about.php
@@ -50,6 +50,32 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					printf(
 						/* translators: 1: WordPress version number, 2: Plural number of bugs. More than one security issue. */
 						_n(
+							'<strong>Version %1$s</strong> addressed a security issue and fixed %2$s bug.',
+							'<strong>Version %1$s</strong> addressed a security issue and fixed %2$s bugs.',
+							1
+						),
+						'6.2.2',
+						'1'
+					);
+					?>
+					<?php
+					printf(
+						/* translators: %s: HelpHub URL. */
+						__( 'For more information, see <a href="%s">the release notes</a>.' ),
+						sprintf(
+							/* translators: %s: WordPress version. */
+							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+							sanitize_title( '6.2.2' )
+						)
+					);
+					?>
+				</p>
+
+				<p>
+					<?php
+					printf(
+						/* translators: 1: WordPress version number, 2: Plural number of bugs. More than one security issue. */
+						_n(
 							'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bug.',
 							'<strong>Version %1$s</strong> addressed some security issues and fixed %2$s bugs.',
 							30

--- a/wp-includes/block-template.php
+++ b/wp-includes/block-template.php
@@ -237,6 +237,8 @@ function get_the_block_template_html() {
 
 	$content = $wp_embed->run_shortcode( $_wp_current_template_content );
 	$content = $wp_embed->autoembed( $content );
+	$content = shortcode_unautop( $content );
+	$content = do_shortcode( $content );
 	$content = do_blocks( $content );
 	$content = wptexturize( $content );
 	$content = convert_smilies( $content );

--- a/wp-includes/blocks/template-part.php
+++ b/wp-includes/blocks/template-part.php
@@ -142,14 +142,14 @@ function render_block_core_template_part( $attributes ) {
 	}
 
 	// Run through the actions that are typically taken on the_content.
+	$content                       = shortcode_unautop( $content );
+	$content                       = do_shortcode( $content );
 	$seen_ids[ $template_part_id ] = true;
 	$content                       = do_blocks( $content );
 	unset( $seen_ids[ $template_part_id ] );
 	$content = wptexturize( $content );
 	$content = convert_smilies( $content );
-	$content = shortcode_unautop( $content );
 	$content = wp_filter_content_tags( $content, "template_part_{$area}" );
-	$content = do_shortcode( $content );
 
 	// Handle embeds for block template parts.
 	global $wp_embed;

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -16,7 +16,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '6.2.1';
+$wp_version = '6.2.2';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
Update from WordPress 6.2.1 to WordPress 6.2.2.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/WordPress), and then visit the test site and confirm that the correct version of WordPress was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new WordPress site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add wp git@github.com:pantheon-systems/WordPress.git
    - git fetch wp
    - git merge wp/update-6.2.2
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
