### PR TITLE
[CMSP-954] Update Default PHP to 8.2

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,7 +3,7 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 8.1
+php_version: 8.2
 
 # See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb
 database:


### PR DESCRIPTION
Upgrades default PHP version to 8.2. This can be overridden at the site level in `pantheon.yml`

----
https://getpantheon.atlassian.net/browse/CMSP-954