### PR TITLE
Update to WordPress 6.9.3. For more information, see https://wordpress.org/news/2026/03/wordpress-6-9-3-and-7-0-beta-4/

### DIFF
--- a/wp-admin/about.php
+++ b/wp-admin/about.php
@@ -67,6 +67,31 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					<?php
 					printf(
 						/* translators: %s: WordPress version. */
+						_n(
+							'<strong>Version %1$s</strong> addressed %2$s bug.',
+							'<strong>Version %1$s</strong> addressed %2$s bugs.',
+							1
+						),
+						'6.9.3',
+						1
+					);
+					?>
+					<?php
+					printf(
+						/* translators: %s: HelpHub URL. */
+						__( 'For more information, see <a href="%s">the release notes</a>.' ),
+						sprintf(
+							/* translators: %s: WordPress version. */
+							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+							sanitize_title( '6.9.3' )
+						)
+					);
+					?>
+				</p>
+				<p>
+					<?php
+					printf(
+						/* translators: %s: WordPress version. */
 						__( '<strong>Version %s</strong> addressed some security issues.' ),
 						'6.9.2'
 					);

--- a/wp-includes/class-wp-block-patterns-registry.php
+++ b/wp-includes/class-wp-block-patterns-registry.php
@@ -174,7 +174,9 @@ final class WP_Block_Patterns_Registry {
 			$patterns = &$this->registered_patterns;
 		}
 
-		$pattern_path = realpath( $patterns[ $pattern_name ]['filePath'] ?? '' );
+		$file_path    = $patterns[ $pattern_name ]['filePath'] ?? '';
+		$is_stringy   = is_string( $file_path ) || ( is_object( $file_path ) && method_exists( $file_path, '__toString' ) );
+		$pattern_path = $is_stringy ? realpath( (string) $file_path ) : null;
 		if (
 			! isset( $patterns[ $pattern_name ]['content'] ) &&
 			is_string( $pattern_path ) &&

--- a/wp-includes/template-loader.php
+++ b/wp-includes/template-loader.php
@@ -111,8 +111,9 @@ if ( wp_using_themes() ) {
 	 *
 	 * @param string $template The path of the template to include.
 	 */
-	$template = apply_filters( 'template_include', $template );
-	$template = is_string( $template ) ? realpath( $template ) : null;
+	$template   = apply_filters( 'template_include', $template );
+	$is_stringy = is_string( $template ) || ( is_object( $template ) && method_exists( $template, '__toString' ) );
+	$template   = $is_stringy ? realpath( (string) $template ) : null;
 	if (
 		is_string( $template ) &&
 		( str_ends_with( $template, '.php' ) || str_ends_with( $template, '.html' ) ) &&

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -16,7 +16,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '6.9.2';
+$wp_version = '6.9.3';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
Update from WordPress 6.9.2 to WordPress 6.9.3.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/WordPress), and then visit the test site and confirm that the correct version of WordPress was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new WordPress site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add wp git@github.com:pantheon-systems/WordPress.git
    - git fetch wp
    - git merge wp/update-6.9.3
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
