### PR TITLE
DELENG-392: Assign ownership to Site Experience team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pantheon-systems/site-experience

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   type: template
   lifecycle: production
-  owner: sitex
+  owner: site-experience

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: WordPress
+  description: WordPress upstream for the Pantheon website platform
+spec:
+  type: template
+  lifecycle: production
+  owner: sitex


### PR DESCRIPTION
# Assign Repository Ownership to Site Experience Team

**Jira:** [DELENG-392](https://getpantheon.atlassian.net/browse/DELENG-392)

## Summary

This PR assigns ownership of this repository to the **@pantheon-systems/site-experience** team by adding `CODEOWNERS` and `catalog-info.yaml` files.

## Changes

- **`.github/CODEOWNERS`** with `* @pantheon-systems/site-experience`
- **`catalog-info.yaml`** with `owner: sitex`

## How Ownership Was Identified

### Background
As part of DELENG's repository ownership initiative, we analyzed **275 repositories** in the pantheon-systems organization that lacked CODEOWNERS files. The goal: assign clear ownership to improve accountability and security.

### Identification Process

**Step 1: Data Collection**
- Audited all pantheon-systems repositories for ownership metadata
- Extracted existing `catalog-info.yaml` owner declarations
- Queried GitHub API for contributor data (top contributor by commits, last contributor by recency)
- Generated comprehensive ownership audit report

**Step 2: Multi-Source Analysis**
Combined data from three sources, prioritized by reliability:

1. **Priority 1: catalog-info.yaml** (most authoritative)
2. **Priority 2: Google Sheet Manual Assignment** 
   - Engineering teams manually reviewed and assigned orphaned repos
   - [Ownership Analysis Spreadsheet](https://docs.google.com/spreadsheets/d/1n3LdJTNkRLHx9nvzm0Ab38b577521noveACNzS_xgcw/edit?gid=1847513807#gid=1847513807)
3. **Priority 3: GitHub Contributor Analysis**
   - Top contributor: user with most commits
   - Last contributor: author of most recent commit
   - Used to validate and increase confidence in assignments

**Step 3: Team Validation**
- Cross-referenced with Site Experience team membership

## Impact

### After this PR merges:
✅ **Code review enforcement** - All PRs to this repo will require Site Experience team review  
✅ **Clear ownership** - Backstage catalog will show Site Experience as owner  
✅ **Team accountability** - Site Experience team is responsible for maintenance and security  
✅ **Discoverability** - Engineers can easily find who owns what  

### No breaking changes:
- Existing workflows continue to work
- No code changes, only metadata files
- Teams can still contribute (CODEOWNERS adds review, doesn't block)

## Testing

- [x] CODEOWNERS uses valid team handle `@pantheon-systems/site-experience`
- [x] catalog-info.yaml uses valid schema (Backstage v1alpha1)
- [x] DELENG-392 referenced for traceability

## Action Required from Site Experience Team

@pantheon-systems/site-experience - Please review and confirm:

1. ✅ Does Site Experience team own this repository?
2. ✅ Any repos that should be assigned to a different team?

Once approved, these changes will:
- Enforce Site Experience team review on all future PRs to this repo
- Make Site Experience the official owner in the Backstage service catalog

---

**Part of the broader repository ownership initiative** - assigning clear ownership to all pantheon-systems repos for better accountability and security.

[DELENG-392]: https://getpantheon.atlassian.net/browse/DELENG-392
