### PR TITLE
[SITE-643] Make WP_HOME and WP_SITEURL definitions conditional

### DIFF
--- a/wp-config-pantheon.php
+++ b/wp-config-pantheon.php
@@ -60,8 +60,12 @@ if (isset($_SERVER['HTTP_HOST'])) {
         $scheme = 'https';
         $_SERVER['HTTPS'] = 'on';
     }
-    define('WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST']);
-    define('WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST']);
+    if (!defined('WP_HOME')) {
+        define('WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST']);
+    }
+    if (!defined('WP_SITEURL')) {
+        define('WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST']);
+    }
 }
 // Don't show deprecations; useful under PHP 5.5
 error_reporting(E_ALL ^ E_DEPRECATED);


### PR DESCRIPTION
## Summary

Previously, `wp-config-pantheon.php` unconditionally called `define()` for `WP_HOME` and `WP_SITEURL`, causing PHP notices when those constants were already defined earlier in the request — for example, in a customer's `wp-config.php`. This was especially visible for AGCDN customers using domain masking.

This PR wraps both `define()` calls in `if (!defined(...))` guards, so customer-defined values are respected and no notices are generated.

Closes #433

Resolves: https://github.com/pantheon-systems/WordPress/issues/353