### PR TITLE
fix(ci): [SITE-5785] Use github-actions[bot] identity for verified commits

### DIFF
--- a/.github/workflows/update-mu-plugin.yml
+++ b/.github/workflows/update-mu-plugin.yml
@@ -163,8 +163,8 @@ jobs:
           timestamp=$(date +%Y%m%d%H%M%S)
           branch="update-mu-plugin-${tag}-${timestamp}"
 
-          git config user.email "bot@getpantheon.com"
-          git config user.name "Pantheon Automation"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
 
           git checkout -b "${branch}"
           git add wp-content/mu-plugins/pantheon-mu-plugin

--- a/.github/workflows/update-mu-plugin.yml
+++ b/.github/workflows/update-mu-plugin.yml
@@ -164,7 +164,7 @@ jobs:
           branch="update-mu-plugin-${tag}-${timestamp}"
 
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
+          git config user.name "Pantheon Automation"
 
           git checkout -b "${branch}"
           git add wp-content/mu-plugins/pantheon-mu-plugin


### PR DESCRIPTION
## Summary

Switch the git identity in `.github/workflows/update-mu-plugin.yml` from `bot@getpantheon.com` / "Pantheon Automation" to `github-actions[bot]`, so the mu-plugin update commits are verified (signed).

## Why

Org-level rulesets now require verified (signed) commits. The previous identity produces **unsigned** commits — e.g. #452 (`Pantheon Automation`, `verified=false`) — which branch protection blocks. Commits made by GitHub Actions are auto-signed when they use the `github-actions[bot]` noreply email (`41898282+github-actions[bot]@users.noreply.github.com`).

Same fix as pantheon-systems/action-package-updater#53 and pantheon-systems/pantheon-mu-plugin#125, applied to this repo's update-mu-plugin workflow.

## Test plan

- [ ] Next `update-mu-plugin` run's commit shows as "Verified" on GitHub.

## References

- Jira: [SITE-5785](https://getpantheon.atlassian.net/browse/SITE-5785)
- Related PRs: pantheon-systems/pantheon-mu-plugin#125, pantheon-systems/action-package-updater#53

[SITE-5785]: https://getpantheon.atlassian.net/browse/SITE-5785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ